### PR TITLE
Introduce optional resource group parameter to deploy script

### DIFF
--- a/Website/Website/deploy/deploy.cmd
+++ b/Website/Website/deploy/deploy.cmd
@@ -1,7 +1,7 @@
 @rem node deploy/zipsite.js
 set webappName=%1
 set subscriptionName=%2
-set resourceGroup=DataX
+if [%3] == [] (set resourceGroup=DataX) else (set resourceGroup=%3)
 
 :deploy
 cmd /c az account set -s %subscriptionName%


### PR DESCRIPTION
Update website deploy script to be able to optionally take a resource group as the third parameter. If parameter is not supplied, it will default to DataX as before.