### PR TITLE
Protect the service by not loading non-Managed assemblies

### DIFF
--- a/Services/DataX.Flow/Flow.ManagementService/Startup.cs
+++ b/Services/DataX.Flow/Flow.ManagementService/Startup.cs
@@ -146,8 +146,15 @@ namespace Flow.Management
                     {
                         await blob.DownloadToStreamAsync(strm);
                         byte[] asseblyBytes = strm.ToArray();
-                        var assembly = Assembly.Load(asseblyBytes);
-                        additionalAssemblies = additionalAssemblies.Append(assembly);
+                        try
+                        {
+                            var assembly = Assembly.Load(asseblyBytes);
+                            additionalAssemblies = additionalAssemblies.Append(assembly);
+                        }
+                        catch(BadImageFormatException)
+                        {
+                            // do nothing and skip the assembly to load as it might be the native assemblies    
+                        }
                     }
                 }
             }

--- a/Services/DataX.Flow/Flow.ManagementService/Startup.cs
+++ b/Services/DataX.Flow/Flow.ManagementService/Startup.cs
@@ -138,6 +138,9 @@ namespace Flow.Management
 
             var dlls = blobStorage.GetCloudBlockBlobs(mefContainerName, mefBlobDirectory);
 
+            // Configure and create a logger instance to add it to MEF container           
+            var logger = _loggerFactory.CreateLogger<RuntimeConfigGeneration>();
+
             foreach (var blob in dlls)
             {
                 if (blob.Name.EndsWith(".dll"))
@@ -151,9 +154,10 @@ namespace Flow.Management
                             var assembly = Assembly.Load(asseblyBytes);
                             additionalAssemblies = additionalAssemblies.Append(assembly);
                         }
-                        catch(BadImageFormatException)
+                        catch(BadImageFormatException be)
                         {
-                            // do nothing and skip the assembly to load as it might be the native assemblies    
+                            // do nothing and skip the assembly to load as it might be a native assembly
+                            logger.LogError(be, "Unable to load Assembly: {0} from the StorageAccount", blob.Name);
                         }
                     }
                 }

--- a/Services/DataX.Flow/Flow.ManagementService/Startup.cs
+++ b/Services/DataX.Flow/Flow.ManagementService/Startup.cs
@@ -138,8 +138,8 @@ namespace Flow.Management
 
             var dlls = blobStorage.GetCloudBlockBlobs(mefContainerName, mefBlobDirectory);
 
-            // Configure and create a logger instance to add it to MEF container           
-            var logger = _loggerFactory.CreateLogger<RuntimeConfigGeneration>();
+            // Configure and create a logger instance to add it to MEF container
+            var logger = _loggerFactory.CreateLogger<Startup>();
 
             foreach (var blob in dlls)
             {

--- a/Services/DataX.Flow/Flow.ManagementService/Startup.cs
+++ b/Services/DataX.Flow/Flow.ManagementService/Startup.cs
@@ -138,7 +138,7 @@ namespace Flow.Management
 
             var dlls = blobStorage.GetCloudBlockBlobs(mefContainerName, mefBlobDirectory);
 
-            // Configure and create a logger instance to add it to MEF container
+            // Configure and create a logger instance
             var logger = _loggerFactory.CreateLogger<Startup>();
 
             foreach (var blob in dlls)

--- a/Services/DataX.Flow/Flow.ManagementService/Startup.cs
+++ b/Services/DataX.Flow/Flow.ManagementService/Startup.cs
@@ -156,7 +156,7 @@ namespace Flow.Management
                         }
                         catch(BadImageFormatException be)
                         {
-                            // do nothing and skip the assembly to load as it might be a native assembly
+                            // Do nothing and skip the assembly to load as it might be a native assembly
                             logger.LogError(be, "Unable to load Assembly: {0} from the StorageAccount", blob.Name);
                         }
                     }


### PR DESCRIPTION
In case of Native dlls, the Assembly.Load can throw BadImageFormatException and this change wraps that call in a try-catch so that the assembly is safely skipped by not loading into the system, required for creating CompositionContainer