### PR TITLE
Adding support for an optional secret for supporting the scenario where the backend services are hosted in an aks cluster

### DIFF
--- a/Website/Website/README.md
+++ b/Website/Website/README.md
@@ -62,7 +62,7 @@ faster performance for production consumption.
 npm run build
 ```
 
-### Deploy production version of website with zip-push otpion on Azure Web App
+### Deploy production version of website with zip-push option on Azure Web App
 * Before deploying
 download and install AzureCLI, login first to get access for deployment:
 ```
@@ -84,4 +84,11 @@ set DATAXDEV_GENERATOR_LOCAL_SERVICE=<local URL of Generator service>
 set DATAXDEV_INTERACTIVE_QUERY_LOCAL_SERVICE=<local URL of Interactive Query service>
 set DATAXDEV_SCHEMA_INFERENCE_LOCAL_SERVICE=<local URL of Schema Inference service>
 set DATAXDEV_LIVE_DATA_LOCAL_SERVICE=<local URL of Live Data service>
+```
+
+### (Optional) How to target services hosted on AKS cluster
+If you are hosting DataX services on an AKS cluster, you can configure the website to target the services hosted on an AKS cluster by defining the following secret in the services keyvault. In the secret value: You only need to define the ones you are hosting on AKS cluster.
+The <External IP> should be added for each of the services where they can be listened to on the AKS cluster as specified in the example below:
+```
+{"Flow.InteractiveQueryService":"http://<External IP for Interactive Query Service>:5000","Flow.SchemaInferenceService":"http://<External IP for Schema Inference Service>:5000","Flow.ManagementService":"http://<External IP for Flow Management Service>:5000","Flow.LiveDataService":"http://<External IP for live Data Service>:5000"}
 ```

--- a/Website/Website/README.md
+++ b/Website/Website/README.md
@@ -87,7 +87,9 @@ set DATAXDEV_LIVE_DATA_LOCAL_SERVICE=<local URL of Live Data service>
 ```
 
 ### (Optional) How to target services hosted on AKS cluster
-If you are hosting DataX services on an AKS cluster, you can configure the website to target the services hosted on an AKS cluster by defining the following secret in the services keyvault. In the secret value: You only need to define the ones you are hosting on AKS cluster.
+If you are hosting DataX services on an AKS cluster, you can configure the website to target the services hosted on an AKS cluster by defining the following secret in the kvServices keyvault. 
+Secret Name: <DATAX_KEYVAULT_SECRET_PREFIX>+"kubernetesServices" where you need to use the prefix: <DATAX_KEYVAULT_SECRET_PREFIX>) from the step 4. 
+Secret Value: In the secret value: You only need to define the ones you are hosting on AKS cluster.
 The <External IP> should be added for each of the services where they can be listened to on the AKS cluster as specified in the example below:
 ```
 {"Flow.InteractiveQueryService":"http://<External IP for Interactive Query Service>:5000","Flow.SchemaInferenceService":"http://<External IP for Schema Inference Service>:5000","Flow.ManagementService":"http://<External IP for Flow Management Service>:5000","Flow.LiveDataService":"http://<External IP for live Data Service>:5000"}

--- a/Website/Website/auth.js
+++ b/Website/Website/auth.js
@@ -91,7 +91,7 @@ function initialize(host) {
 
     // Updates will be made once the ARM support is added.
     // This expects a secret with a value that is a json object comprising of all the backend service names and the external IP addresses as exposed by AKS where each of them can be listened to.
-    const kubernetesServices = env.kubernetesServices;
+    const kubernetesServices = env.kubernetesServices ? env.kubernetesServices : null;
 
     function resourceToResourceId(resource) {
         if (resource === 'service') {
@@ -212,7 +212,7 @@ function initialize(host) {
         let url;
         if (env.localServices[query.service]) {
             url = `${env.localServices[query.service]}/api/${query.api}`;
-        } else if (`${kubernetesServices[query.service]}`) {
+        } else if (kubernetesServices != null && `${kubernetesServices[query.service]}`) {
             url = `${kubernetesServices[query.service]}/api/${query.api}`;
         } else {
             url = `${serviceClusterUrl}/api/${query.application}/${query.service}/${query.api}`;

--- a/Website/Website/auth.js
+++ b/Website/Website/auth.js
@@ -91,7 +91,7 @@ function initialize(host) {
 
     // Updates will be made once the ARM support is added.
     // This expects a secret with a value that is a json object comprising of all the backend service names and the external IP addresses as exposed by AKS where each of them can be listened to.
-    const kubernetesServices = JSON.parse(env.kubernetesServices);
+    const kubernetesServices = env.kubernetesServices;
 
     function resourceToResourceId(resource) {
         if (resource === 'service') {

--- a/Website/Website/auth.js
+++ b/Website/Website/auth.js
@@ -89,6 +89,10 @@ function initialize(host) {
     const authContext = new AuthenticationContext(`https://login.microsoftonline.com/${tenantName}`);
     const serviceClusterUrl = env.serviceClusterUrl;
 
+    // Updates will be made once the ARM support is added.
+    // This expects a secret with a value that is a json object comprising of all the backend service names and the external IP addresses as exposed by AKS where each of them can be listened to.
+    const kubernetesServices = JSON.parse(env.kubernetesServices);
+
     function resourceToResourceId(resource) {
         if (resource === 'service') {
             return env.serviceResourceId;
@@ -186,12 +190,13 @@ function initialize(host) {
     };
 
     /**
-     * call services on service fabric
+     * call services on service fabric or services hosted on Kubernetes
      * @param {http request coming from client} req
      * @param {query object to call Service Fabric service} query
      * Example:
      * {
-     *   application: "DataX.Flow",
+     *   application: "DataX.Flow",// This does not apply the kubernetes scenario. This applies only to the ServiceFabric scenario.
+     *   the rest of the parameters stay the same for the Kubernetes scenario as well.
      *   service: "Flow.ManagementService",
      *   method: "GET", // or POST
      *   headers: {"Content-type": "application/json"} // optional headers
@@ -207,6 +212,8 @@ function initialize(host) {
         let url;
         if (env.localServices[query.service]) {
             url = `${env.localServices[query.service]}/api/${query.api}`;
+        } else if (`${kubernetesServices[query.service]}`) {
+            url = `${kubernetesServices[query.service]}/api/${query.api}`;
         } else {
             url = `${serviceClusterUrl}/api/${query.application}/${query.service}/${query.api}`;
         }

--- a/Website/Website/auth.js
+++ b/Website/Website/auth.js
@@ -89,10 +89,6 @@ function initialize(host) {
     const authContext = new AuthenticationContext(`https://login.microsoftonline.com/${tenantName}`);
     const serviceClusterUrl = env.serviceClusterUrl;
 
-    // Updates will be made once the ARM support is added.
-    // This expects a secret with a value that is a json object comprising of all the backend service names and the external IP addresses as exposed by AKS where each of them can be listened to.
-    const kubernetesServices = env.kubernetesServices ? env.kubernetesServices : null;
-
     function resourceToResourceId(resource) {
         if (resource === 'service') {
             return env.serviceResourceId;
@@ -212,8 +208,8 @@ function initialize(host) {
         let url;
         if (env.localServices[query.service]) {
             url = `${env.localServices[query.service]}/api/${query.api}`;
-        } else if (kubernetesServices != null && `${kubernetesServices[query.service]}`) {
-            url = `${kubernetesServices[query.service]}/api/${query.api}`;
+        } else if (env.kubernetesServices && env.kubernetesServices[query.service]) {
+            url = `${env.kubernetesServices[query.service]}/api/${query.api}`;
         } else {
             url = `${serviceClusterUrl}/api/${query.application}/${query.service}/${query.api}`;
         }

--- a/Website/Website/securedSettings.js
+++ b/Website/Website/securedSettings.js
@@ -53,7 +53,8 @@ module.exports = async function(host) {
                 },
                 async function() {
                     let kubernetesServices = await getSecret('kubernetesServices');
-                    // JSON object looks like this:
+                    // Secret Name: <DATAX_KEYVAULT_SECRET_PREFIX>+"kubernetesServices" where you need to use the prefix: <DATAX_KEYVAULT_SECRET_PREFIX>) needs to be specified in the keyvault on the azure portal that starts with kvServices
+                    // Secret value is a JSON object looks like this:
                     // {"Flow.InteractiveQueryService":"http://<External IP for Interactive Query Service>:5000","Flow.SchemaInferenceService":"http://<External IP for Schema Inference Service>:5000","Flow.ManagementService":"http://<External IP for Flow Management Service>:5000","Flow.LiveDataService":"http://<External IP for live Data Service>:5000"}
                     if (kubernetesServices) {
                         env.kubernetesServices = JSON.parse(kubernetesServices);

--- a/Website/Website/securedSettings.js
+++ b/Website/Website/securedSettings.js
@@ -54,7 +54,7 @@ module.exports = async function(host) {
                 async function() {
                     let kubernetesServices = await getSecret('kubernetesServices');
                     // JSON object looks like this:
-                    // {"Flow.InteractiveQueryService":"http://<ExternalIP for Interactive Query Service>:5000","Flow.SchemaInferenceService":"http://<External IP for Schema Inference Service>:5000","Flow.ManagementService":"http://<External IP for Flow Management Service>:5000","Flow.LiveDataService":"http://<ExternalIP for live Data Service>:5000"}
+                    // {"Flow.InteractiveQueryService":"http://<External IP for Interactive Query Service>:5000","Flow.SchemaInferenceService":"http://<External IP for Schema Inference Service>:5000","Flow.ManagementService":"http://<External IP for Flow Management Service>:5000","Flow.LiveDataService":"http://<External IP for live Data Service>:5000"}
                     if (kubernetesServices) {
                         env.kubernetesServices = JSON.parse(kubernetesServices);
                     }

--- a/Website/Website/securedSettings.js
+++ b/Website/Website/securedSettings.js
@@ -51,6 +51,10 @@ module.exports = async function(host) {
                     env.mongoDbUrl = await getSecretOrThrow('mongoDbUrl');
                     env.mongoSharedDbUrl = await getSecretOrThrow('mongoSharedDbUrl').catch(err => env.mongoDbUrl);
                 },
+                ,
+                async function() {
+                    env.kubernetesServices = await getSecret('kubernetesServices');
+                },
                 async function() {
                     let redisDataConnectionString = await getSecret('redisDataConnectionString');
                     if (redisDataConnectionString)

--- a/Website/Website/securedSettings.js
+++ b/Website/Website/securedSettings.js
@@ -51,9 +51,13 @@ module.exports = async function(host) {
                     env.mongoDbUrl = await getSecretOrThrow('mongoDbUrl');
                     env.mongoSharedDbUrl = await getSecretOrThrow('mongoSharedDbUrl').catch(err => env.mongoDbUrl);
                 },
-                ,
                 async function() {
-                    env.kubernetesServices = await getSecret('kubernetesServices');
+                    let kubernetesServices = await getSecret('kubernetesServices');
+                    // JSON object looks like this:
+                    // {"Flow.InteractiveQueryService":"http://<ExternalIP for Interactive Query Service>:5000","Flow.SchemaInferenceService":"http://<External IP for Schema Inference Service>:5000","Flow.ManagementService":"http://<External IP for Flow Management Service>:5000","Flow.LiveDataService":"http://<ExternalIP for live Data Service>:5000"}
+                    if (kubernetesServices) {
+                        env.kubernetesServices = JSON.parse(kubernetesServices);
+                    }
                 },
                 async function() {
                     let redisDataConnectionString = await getSecret('redisDataConnectionString');


### PR DESCRIPTION
Adding support for an optional secret for supporting the scenario where the backend services are hosted in an aks cluster. The secret is a key value pair for each servicename and the ip address where the service can be listened at.