### PR TITLE
Fixing and adding a check for Databricks vs HDInsight when saving and resolving the spark job params

### DIFF
--- a/Services/DataX.Config/DataX.Config/ConfigGeneration/Processor/S500_ResolveSparkJobParams.cs
+++ b/Services/DataX.Config/DataX.Config/ConfigGeneration/Processor/S500_ResolveSparkJobParams.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Composition;
 using System.Text;
 using System.Threading.Tasks;
+using DataX.Config.ConfigDataModel;
 
 namespace DataX.Config.ConfigGeneration.Processor
 {
@@ -26,10 +27,17 @@ namespace DataX.Config.ConfigGeneration.Processor
         public const string TokenName_DatabricksToken = "guiSparkDatabricksToken";
         public const string TokenName_SparkJobDatabricksAutoScale = "guiSparkJobDatabricksAutoScale";
 
+        [ImportingConstructor]
+        public ResolveSparkJobParams(ConfigGenConfiguration conf)
+        {
+            Configuration = conf;
+        }
+        private ConfigGenConfiguration Configuration { get; }
         public override async Task<string> Process(FlowDeploymentSession flowToDeploy)
         {
             var guiConfig = flowToDeploy.Config?.GetGuiConfig();
             if (guiConfig == null)
+                
             {
                 // If guiConfig is empty, get the number of executors from job common token and convert it to integer
                 var executorsString = flowToDeploy.Config?.CommonProcessor?.JobCommonTokens?.GetOrDefault("sparkJobNumExecutors", null);
@@ -50,7 +58,7 @@ namespace DataX.Config.ConfigGeneration.Processor
             {
                 throw new ConfigGenerationException($"Invalid value for process.jobconfig.jobNumExecutors:'{numExecutorsString}'.");
             }
-
+            
             flowToDeploy.SetObjectToken(TokenName_SparkJobNumExecutors, numExecutors);
 
             // Setting TokenName_SparkJobJobExecutorMemory
@@ -62,32 +70,34 @@ namespace DataX.Config.ConfigGeneration.Processor
 
             flowToDeploy.SetStringToken(TokenName_SparkJobJobExecutorMemory, $"{jobExecutorMemory}m");
 
-            // Setting TokenName_SparkJobDatabricksMinWorkers
-            var jobDatabricksMinWorkersString = guiConfig?.Process?.JobConfig?.JobDatabricksMinWorkers;
-            if (!int.TryParse(jobDatabricksMinWorkersString, out int jobDatabricksMinWorkers))
+            if (Configuration[Constants.ConfigSettingName_SparkType] == Config.ConfigDataModel.Constants.SparkTypeDataBricks)
             {
-                throw new ConfigGenerationException($"Invalid value for process.jobconfig.jobDatabricksMinWorkers:'{jobDatabricksMinWorkersString}'.");
+                // Setting TokenName_SparkJobDatabricksMinWorkers
+                var jobDatabricksMinWorkersString = guiConfig?.Process?.JobConfig?.JobDatabricksMinWorkers;
+                if (!int.TryParse(jobDatabricksMinWorkersString, out int jobDatabricksMinWorkers))
+                {
+                    throw new ConfigGenerationException($"Invalid value for process.jobconfig.jobDatabricksMinWorkers:'{jobDatabricksMinWorkersString}'.");
+                }
+
+                flowToDeploy.SetStringToken(TokenName_SparkJobDatabricksMinWorkers, $"{jobDatabricksMinWorkers}");
+
+                // Setting TokenName_SparkJobDatabricksMaxWorkers
+                var jobDatabricksMaxWorkersString = guiConfig?.Process?.JobConfig?.JobDatabricksMaxWorkers;
+                if (!int.TryParse(jobDatabricksMaxWorkersString, out int jobDatabricksMaxWorkers))
+                {
+                    throw new ConfigGenerationException($"Invalid value for process.jobconfig.jobDatabricksMaxWorkers:'{jobDatabricksMaxWorkersString}'.");
+                }
+
+                flowToDeploy.SetStringToken(TokenName_SparkJobDatabricksMaxWorkers, $"{jobDatabricksMaxWorkers}");
+
+                // Setting TokenName_DatabricksToken
+                var jobDatabricksTokenString = guiConfig?.DatabricksToken;
+                flowToDeploy.SetStringToken(TokenName_DatabricksToken, $"{jobDatabricksTokenString}");
+
+                // Setting TokenName_SparkJobDatabricksAutoScale
+                var jobDatabricksAutoScaleString = guiConfig?.Process?.JobConfig?.JobDatabricksAutoScale;
+                flowToDeploy.SetStringToken(TokenName_SparkJobDatabricksAutoScale, $"{jobDatabricksAutoScaleString}");
             }
-
-            flowToDeploy.SetStringToken(TokenName_SparkJobDatabricksMinWorkers, $"{jobDatabricksMinWorkers}");
-
-            // Setting TokenName_SparkJobDatabricksMaxWorkers
-            var jobDatabricksMaxWorkersString = guiConfig?.Process?.JobConfig?.JobDatabricksMaxWorkers;
-            if (!int.TryParse(jobDatabricksMaxWorkersString, out int jobDatabricksMaxWorkers))
-            {
-                throw new ConfigGenerationException($"Invalid value for process.jobconfig.jobDatabricksMaxWorkers:'{jobDatabricksMaxWorkersString}'.");
-            }
-
-            flowToDeploy.SetStringToken(TokenName_SparkJobDatabricksMaxWorkers, $"{jobDatabricksMaxWorkers}");
-
-            // Setting TokenName_DatabricksToken
-            var jobDatabricksTokenString = guiConfig?.DatabricksToken;
-            flowToDeploy.SetStringToken(TokenName_DatabricksToken, $"{jobDatabricksTokenString}");
-
-            // Setting TokenName_SparkJobDatabricksAutoScale
-            var jobDatabricksAutoScaleString = guiConfig?.Process?.JobConfig?.JobDatabricksAutoScale;
-            flowToDeploy.SetStringToken(TokenName_SparkJobDatabricksAutoScale, $"{jobDatabricksAutoScaleString}");
-
             await Task.Yield();
             return "done";
         }

--- a/Services/DataX.Flow/DataX.Flow.Common/Helper.cs
+++ b/Services/DataX.Flow/DataX.Flow.Common/Helper.cs
@@ -56,7 +56,7 @@ namespace DataX.Flow.Common
         /// <returns>true if it is a secret, otherwise false</returns>
         public static bool IsKeyVault(string value)
         {
-            return (value.StartsWith(GetKeyValutNamePrefix()) || value.StartsWith(GetSecretScopePrefix()));
+            return value.StartsWith(GetKeyValutNamePrefix()) || value.StartsWith(GetSecretScopePrefix());
         }
 
         /// <summary>


### PR DESCRIPTION
Fixing and adding a check for Databricks vs HDInsight when saving and resolving the spark job params