### PR TITLE
Refactor DataX.Flow to support batch scenarios better

### DIFF
--- a/Services/DataX.Config/DataX.Config.DatabricksClient/DatabricksClient.cs
+++ b/Services/DataX.Config/DataX.Config.DatabricksClient/DatabricksClient.cs
@@ -156,6 +156,7 @@ namespace DataX.Config.DatabricksClient
 
         public async Task<SparkJobSyncResult[]> GetJobs()
         {
+            await Task.CompletedTask;
             throw new NotImplementedException();
         }
     }

--- a/Services/DataX.Config/DataX.Config.KeyVault/KeyVaultClient.cs
+++ b/Services/DataX.Config/DataX.Config.KeyVault/KeyVaultClient.cs
@@ -46,7 +46,7 @@ namespace DataX.Config.KeyVault
         public async Task<string> SaveSecretAsync(string keyvaultName, string secretName, string secretValue, string sparkType, bool hashSuffix = false)
         {
             var finalSecretName = hashSuffix ? (secretName + "-" + HashGenerator.GetHashCode(secretValue)) : secretName;
-            var uriPrefix = (sparkType != null && sparkType == Constants.SparkTypeDataBricks) ? Constants.PrefixSecretScope : Constants.PrefixKeyVault;
+            var uriPrefix = GetUriPrefix(sparkType);
             await GetKeyVault().SaveSecretStringAsync(keyvaultName, finalSecretName, secretValue);
             return SecretUriParser.ComposeUri(keyvaultName, finalSecretName, uriPrefix);
         }
@@ -56,6 +56,11 @@ namespace DataX.Config.KeyVault
             SecretUriParser.ParseSecretUri(secretUri, out string keyvaultName, out string secretName);
             await GetKeyVault().SaveSecretStringAsync(keyvaultName, secretName, secretValue);
             return secretUri;
+        }
+
+        public string GetUriPrefix(string sparkType)
+        {
+            return (sparkType != null && sparkType == Constants.SparkTypeDataBricks) ? Constants.PrefixSecretScope : Constants.PrefixKeyVault;
         }
     }
 }

--- a/Services/DataX.Config/DataX.Config.KeyVault/KeyVaultClient.cs
+++ b/Services/DataX.Config/DataX.Config.KeyVault/KeyVaultClient.cs
@@ -50,5 +50,12 @@ namespace DataX.Config.KeyVault
             await GetKeyVault().SaveSecretStringAsync(keyvaultName, finalSecretName, secretValue);
             return SecretUriParser.ComposeUri(keyvaultName, finalSecretName, uriPrefix);
         }
+
+        public async Task<string> SaveSecretAsync(string secretUri, string secretValue)
+        {
+            SecretUriParser.ParseSecretUri(secretUri, out string keyvaultName, out string secretName);
+            await GetKeyVault().SaveSecretStringAsync(keyvaultName, secretName, secretValue);
+            return secretUri;
+        }
     }
 }

--- a/Services/DataX.Config/DataX.Config.Local/KeyVaultClient.cs
+++ b/Services/DataX.Config/DataX.Config.Local/KeyVaultClient.cs
@@ -2,6 +2,7 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License
 // *********************************************************************
+using DataX.Config.ConfigDataModel;
 using System.Composition;
 using System.Threading.Tasks;
 
@@ -33,6 +34,11 @@ namespace DataX.Config.Local
         public Task<string> SaveSecretAsync(string secretUri, string secretValue)
         {
             return Task.FromResult(secretValue);
+        }
+
+        public string GetUriPrefix(string sparkType)
+        {
+            return (sparkType != null && sparkType == Constants.SparkTypeDataBricks) ? Constants.PrefixSecretScope : Constants.PrefixKeyVault;
         }
     }
 }

--- a/Services/DataX.Config/DataX.Config.Local/KeyVaultClient.cs
+++ b/Services/DataX.Config/DataX.Config.Local/KeyVaultClient.cs
@@ -29,5 +29,10 @@ namespace DataX.Config.Local
         {
             return Task.FromResult(secretValue);
         }
+
+        public Task<string> SaveSecretAsync(string secretUri, string secretValue)
+        {
+            return Task.FromResult(secretValue);
+        }
     }
 }

--- a/Services/DataX.Config/DataX.Config.Test/Mock/KeyVaultClient.cs
+++ b/Services/DataX.Config/DataX.Config.Test/Mock/KeyVaultClient.cs
@@ -43,5 +43,11 @@ namespace DataX.Config.Test.Mock
             await Task.Yield();
             return $"{uriPrefix}://{keyvaultName}/{finalSecretName}";
         }
+
+        public async Task<string> SaveSecretAsync(string secretUri, string secretValue)
+        {
+            await Task.Yield();
+            return secretUri;
+        }
     }
 }

--- a/Services/DataX.Config/DataX.Config.Test/Mock/KeyVaultClient.cs
+++ b/Services/DataX.Config/DataX.Config.Test/Mock/KeyVaultClient.cs
@@ -38,7 +38,7 @@ namespace DataX.Config.Test.Mock
 
         public async Task<string> SaveSecretAsync(string keyvaultName, string secretName, string secretValue, string sparkType, bool hashSuffix = false)
         {
-            var uriPrefix = (sparkType != null && sparkType == Constants.SparkTypeDataBricks) ? Constants.PrefixSecretScope : Constants.PrefixKeyVault;
+            var uriPrefix = GetUriPrefix(sparkType);
             var finalSecretName = hashSuffix ? (secretName + "-" + HashGenerator.GetHashCode(secretValue)) : secretName;
             await Task.Yield();
             return $"{uriPrefix}://{keyvaultName}/{finalSecretName}";
@@ -48,6 +48,11 @@ namespace DataX.Config.Test.Mock
         {
             await Task.Yield();
             return secretUri;
+        }
+
+        public string GetUriPrefix(string sparkType)
+        {
+            return (sparkType != null && sparkType == Constants.SparkTypeDataBricks) ? Constants.PrefixSecretScope : Constants.PrefixKeyVault;
         }
     }
 }

--- a/Services/DataX.Config/DataX.Config/Client/IKeyVaultClient.cs
+++ b/Services/DataX.Config/DataX.Config/Client/IKeyVaultClient.cs
@@ -41,5 +41,12 @@ namespace DataX.Config
         /// <param name="secretValue">value of the secret</param>
         /// <returns>secret id</returns>
         Task<string> SaveSecretAsync(string secretUri, string secretValue);
+
+        /// <summary>
+        /// Generate a secret uri prefix based on sparkType
+        /// </summary>
+        /// <param name="sparkType">spark type</param>
+        /// <returns></returns>
+        string GetUriPrefix(string sparkType);
     }
 }

--- a/Services/DataX.Config/DataX.Config/Client/IKeyVaultClient.cs
+++ b/Services/DataX.Config/DataX.Config/Client/IKeyVaultClient.cs
@@ -33,5 +33,13 @@ namespace DataX.Config
         /// <param name="hashSuffix">specify whether the generated secret uri has a hashed suffix, by default it is false</param>
         /// <returns>secret id</returns>
         Task<string> SaveSecretAsync(string keyvaultName, string secretName, string secretValue, string sparkType, bool hashSuffix = false);
+
+        /// <summary>
+        /// Save the secret and return the secret uri
+        /// </summary>
+        /// <param name="secretUri">Uri of the secret</param>
+        /// <param name="secretValue">value of the secret</param>
+        /// <returns>secret id</returns>
+        Task<string> SaveSecretAsync(string secretUri, string secretValue);
     }
 }

--- a/Services/DataX.Config/DataX.Config/ConfigGeneration/Processor/S450_PrepareTransformFile.cs
+++ b/Services/DataX.Config/DataX.Config/ConfigGeneration/Processor/S450_PrepareTransformFile.cs
@@ -18,7 +18,7 @@ namespace DataX.Config.ConfigGeneration.Processor
     /// </summary>
     [Shared]
     [Export(typeof(IFlowDeploymentProcessor))]
-    public class GenerateTransformFile : ProcessorBase
+    public class PrepareTransformFile : ProcessorBase
     {
         public const string TokenName_TransformFile = "processTransforms";
         public const string AttachmentName_CodeGenObject = "rulesCode";
@@ -28,7 +28,7 @@ namespace DataX.Config.ConfigGeneration.Processor
         private IRuntimeConfigStorage RuntimeStorage { get; }
 
         [ImportingConstructor]
-        public GenerateTransformFile(IKeyVaultClient keyvaultClient, IRuntimeConfigStorage runtimeStorage, ConfigGenConfiguration conf)
+        public PrepareTransformFile(IKeyVaultClient keyvaultClient, IRuntimeConfigStorage runtimeStorage, ConfigGenConfiguration conf)
         {
             KeyVaultClient = keyvaultClient;
             RuntimeStorage = runtimeStorage;
@@ -51,7 +51,7 @@ namespace DataX.Config.ConfigGeneration.Processor
             }
             string queries = string.Join("\n", guiConfig.Process?.Queries);
 
-            string ruleDefinitions =  RuleDefinitionGenerator.GenerateRuleDefinitions(guiConfig.Rules, config.Name);
+            string ruleDefinitions = RuleDefinitionGenerator.GenerateRuleDefinitions(guiConfig.Rules, config.Name);
             RulesCode rulesCode = CodeGen.GenerateCode(queries, ruleDefinitions, config.Name);
 
             Ensure.NotNull(rulesCode, "rulesCode");
@@ -59,18 +59,17 @@ namespace DataX.Config.ConfigGeneration.Processor
             // Save the rulesCode object for downstream processing
             flowToDeploy.SetAttachment(AttachmentName_CodeGenObject, rulesCode);
 
-            var runtimeConfigBaseFolder = flowToDeploy.GetTokenString(PrepareJobConfigVariables.TokenName_RuntimeConfigFolder);
-            Ensure.NotNull(runtimeConfigBaseFolder, "runtimeConfigBaseFolder");
-
             var runtimeKeyVaultName = flowToDeploy.GetTokenString(PortConfigurationSettings.TokenName_RuntimeKeyVaultName);
             Ensure.NotNull(runtimeKeyVaultName, "runtimeKeyVaultName");
 
-            var filePath = ResourcePathUtil.Combine(runtimeConfigBaseFolder, $"{config.Name}-combined.txt");
-            var transformFilePath = await RuntimeStorage.SaveFile(filePath, rulesCode.Code);
             var secretName = $"{config.Name}-transform";
-            var transformFileSecret = await KeyVaultClient.SaveSecretAsync(runtimeKeyVaultName, secretName, transformFilePath, Configuration.TryGet(Constants.ConfigSettingName_SparkType, out string sparkType) ? sparkType : null);
+            Configuration.TryGet(Constants.ConfigSettingName_SparkType, out string sparkType);
+            var uriPrefix = (sparkType != null && sparkType == Constants.SparkTypeDataBricks) ? Constants.PrefixSecretScope : Constants.PrefixKeyVault;
+
+            var transformFileSecret = $"{uriPrefix}://{runtimeKeyVaultName}/{secretName}";
             flowToDeploy.SetStringToken(TokenName_TransformFile, transformFileSecret);
 
+            await Task.CompletedTask;
             return "done";
         }
     }

--- a/Services/DataX.Config/DataX.Config/ConfigGeneration/Processor/S450_PrepareTransformFile.cs
+++ b/Services/DataX.Config/DataX.Config/ConfigGeneration/Processor/S450_PrepareTransformFile.cs
@@ -40,7 +40,10 @@ namespace DataX.Config.ConfigGeneration.Processor
             return 450;
         }
 
-
+        /// <summary>
+        /// Generate and set the info for the transform file which will be used to generate JobConfig
+        /// </summary>
+        /// <returns></returns>
         public override async Task<string> Process(FlowDeploymentSession flowToDeploy)
         {
             var config = flowToDeploy.Config;

--- a/Services/DataX.Config/DataX.Config/ConfigGeneration/Processor/S450_PrepareTransformFile.cs
+++ b/Services/DataX.Config/DataX.Config/ConfigGeneration/Processor/S450_PrepareTransformFile.cs
@@ -10,6 +10,7 @@ using System.Composition;
 using System.Linq;
 using System.Threading.Tasks;
 using DataX.Config.ConfigDataModel;
+using DataX.Utility.KeyVault;
 
 namespace DataX.Config.ConfigGeneration.Processor
 {
@@ -67,9 +68,8 @@ namespace DataX.Config.ConfigGeneration.Processor
 
             var secretName = $"{config.Name}-transform";
             Configuration.TryGet(Constants.ConfigSettingName_SparkType, out string sparkType);
-            var uriPrefix = (sparkType != null && sparkType == Constants.SparkTypeDataBricks) ? Constants.PrefixSecretScope : Constants.PrefixKeyVault;
-
-            var transformFileSecret = $"{uriPrefix}://{runtimeKeyVaultName}/{secretName}";
+            var uriPrefix = KeyVaultClient.GetUriPrefix(sparkType);
+            var transformFileSecret = SecretUriParser.ComposeUri(runtimeKeyVaultName, secretName, uriPrefix);
             flowToDeploy.SetStringToken(TokenName_TransformFile, transformFileSecret);
 
             await Task.CompletedTask;

--- a/Services/DataX.Config/DataX.Config/ConfigGeneration/Processor/S500_PrepareProjectionFile.cs
+++ b/Services/DataX.Config/DataX.Config/ConfigGeneration/Processor/S500_PrepareProjectionFile.cs
@@ -5,6 +5,7 @@
 using DataX.Config.ConfigDataModel;
 using DataX.Config.Utility;
 using DataX.Contract;
+using DataX.Utility.KeyVault;
 using System;
 using System.Collections.Generic;
 using System.Composition;
@@ -49,9 +50,8 @@ namespace DataX.Config.ConfigGeneration.Processor
 
             var secretName = $"{config.Name}-projectionfile";
             Configuration.TryGet(Constants.ConfigSettingName_SparkType, out string sparkType);
-            var uriPrefix = (sparkType != null && sparkType == Constants.SparkTypeDataBricks) ? Constants.PrefixSecretScope : Constants.PrefixKeyVault;
-
-            var projectionFileSecret = $"{uriPrefix}://{runtimeKeyVaultName}/{secretName}";
+            var uriPrefix = KeyVaultClient.GetUriPrefix(sparkType);
+            var projectionFileSecret = SecretUriParser.ComposeUri(runtimeKeyVaultName, secretName, uriPrefix);
             flowToDeploy.SetObjectToken(TokenName_ProjectionFiles, new string[] { projectionFileSecret });
 
             await Task.CompletedTask;

--- a/Services/DataX.Config/DataX.Config/ConfigGeneration/Processor/S500_PrepareProjectionFile.cs
+++ b/Services/DataX.Config/DataX.Config/ConfigGeneration/Processor/S500_PrepareProjectionFile.cs
@@ -33,7 +33,11 @@ namespace DataX.Config.ConfigGeneration.Processor
         private ConfigGenConfiguration Configuration { get; }
         private IRuntimeConfigStorage RuntimeStorage { get; }
         private IKeyVaultClient KeyVaultClient { get; }
-        
+
+        /// <summary>
+        /// Generate and set the info for the projection file which will be used to generate JobConfig
+        /// </summary>
+        /// <returns></returns>
         public override async Task<string> Process(FlowDeploymentSession flowToDeploy)
         {
             var config = flowToDeploy.Config;

--- a/Services/DataX.Config/DataX.Config/ConfigGeneration/Processor/S500_PrepareSchemaFile.cs
+++ b/Services/DataX.Config/DataX.Config/ConfigGeneration/Processor/S500_PrepareSchemaFile.cs
@@ -35,6 +35,10 @@ namespace DataX.Config.ConfigGeneration.Processor
         private IKeyVaultClient KeyVaultClient { get; }
         private IRuntimeConfigStorage RuntimeStorage { get; }
 
+        /// <summary>
+        /// Generate and set the info for the input schema file which will be used to generate JobConfig
+        /// </summary>
+        /// <returns></returns>
         public override async Task<string> Process(FlowDeploymentSession flowToDeploy)
         {
             var config = flowToDeploy.Config;

--- a/Services/DataX.Config/DataX.Config/ConfigGeneration/Processor/S500_PrepareSchemaFile.cs
+++ b/Services/DataX.Config/DataX.Config/ConfigGeneration/Processor/S500_PrepareSchemaFile.cs
@@ -1,0 +1,55 @@
+﻿// *********************************************************************
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License
+// *********************************************************************
+using DataX.Config.ConfigDataModel;
+using DataX.Config.Utility;
+using DataX.Contract;
+using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DataX.Config.ConfigGeneration.Processor
+{
+    /// <summary>
+    /// Produce the schema file section
+    /// </summary>
+    [Shared]
+    [Export(typeof(IFlowDeploymentProcessor))]
+    public class PrepareSchemaFile: ProcessorBase
+    {
+        public const string TokenName_InputSchemaFilePath = "inputSchemaFilePath";
+
+        [ImportingConstructor]
+        public PrepareSchemaFile(IKeyVaultClient keyvaultClient, IRuntimeConfigStorage runtimeStorage, ConfigGenConfiguration conf)
+        {
+            KeyVaultClient = keyvaultClient;
+            RuntimeStorage = runtimeStorage;
+            Configuration = conf;
+        }
+
+        private ConfigGenConfiguration Configuration { get; }
+        private IKeyVaultClient KeyVaultClient { get; }
+        private IRuntimeConfigStorage RuntimeStorage { get; }
+
+        public override async Task<string> Process(FlowDeploymentSession flowToDeploy)
+        {
+            var config = flowToDeploy.Config;
+            var runtimeKeyVaultName = flowToDeploy.GetTokenString(PortConfigurationSettings.TokenName_RuntimeKeyVaultName);
+            Ensure.NotNull(runtimeKeyVaultName, "runtimeKeyVaultName");
+
+            var secretName = $"{config.Name}-inputschemafile";
+            Configuration.TryGet(Constants.ConfigSettingName_SparkType, out string sparkType);
+            var uriPrefix = (sparkType != null && sparkType == Constants.SparkTypeDataBricks) ? Constants.PrefixSecretScope : Constants.PrefixKeyVault;
+
+            var schemaFileSecret = $"{uriPrefix}://{runtimeKeyVaultName}/{secretName}";
+            flowToDeploy.SetStringToken(TokenName_InputSchemaFilePath, schemaFileSecret);
+
+            await Task.CompletedTask;
+            return "done";
+        }
+    }
+}

--- a/Services/DataX.Config/DataX.Config/ConfigGeneration/Processor/S500_PrepareSchemaFile.cs
+++ b/Services/DataX.Config/DataX.Config/ConfigGeneration/Processor/S500_PrepareSchemaFile.cs
@@ -5,6 +5,7 @@
 using DataX.Config.ConfigDataModel;
 using DataX.Config.Utility;
 using DataX.Contract;
+using DataX.Utility.KeyVault;
 using System;
 using System.Collections.Generic;
 using System.Composition;
@@ -47,9 +48,8 @@ namespace DataX.Config.ConfigGeneration.Processor
 
             var secretName = $"{config.Name}-inputschemafile";
             Configuration.TryGet(Constants.ConfigSettingName_SparkType, out string sparkType);
-            var uriPrefix = (sparkType != null && sparkType == Constants.SparkTypeDataBricks) ? Constants.PrefixSecretScope : Constants.PrefixKeyVault;
-
-            var schemaFileSecret = $"{uriPrefix}://{runtimeKeyVaultName}/{secretName}";
+            var uriPrefix = KeyVaultClient.GetUriPrefix(sparkType);
+            var schemaFileSecret = SecretUriParser.ComposeUri(runtimeKeyVaultName, secretName, uriPrefix);
             flowToDeploy.SetStringToken(TokenName_InputSchemaFilePath, schemaFileSecret);
 
             await Task.CompletedTask;

--- a/Services/DataX.Config/DataX.Config/ConfigGeneration/Processor/S500_ResolveOutputs.cs
+++ b/Services/DataX.Config/DataX.Config/ConfigGeneration/Processor/S500_ResolveOutputs.cs
@@ -54,7 +54,7 @@ namespace DataX.Config.ConfigGeneration.Processor
                 return "no gui input, skipped";
             }
 
-            var rulesCode = flowToDeploy.GetAttachment<RulesCode>(GenerateTransformFile.AttachmentName_CodeGenObject);
+            var rulesCode = flowToDeploy.GetAttachment<RulesCode>(PrepareTransformFile.AttachmentName_CodeGenObject);
             Ensure.NotNull(rulesCode, "rulesCode");
             Ensure.NotNull(rulesCode.MetricsRoot, "rulesCode.MetricsRoot");
             Ensure.NotNull(rulesCode.MetricsRoot.metrics, "rulesCode.MetricsRoot.metrics");

--- a/Services/DataX.Config/DataX.Config/ConfigGeneration/Processor/S500_ResolveStateTable.cs
+++ b/Services/DataX.Config/DataX.Config/ConfigGeneration/Processor/S500_ResolveStateTable.cs
@@ -41,7 +41,7 @@ namespace DataX.Config.ConfigGeneration.Processor
                 return "no gui input, skipped.";
             }
 
-            var rulesCode = flowToDeploy.GetAttachment<RulesCode>(GenerateTransformFile.AttachmentName_CodeGenObject);
+            var rulesCode = flowToDeploy.GetAttachment<RulesCode>(PrepareTransformFile.AttachmentName_CodeGenObject);
             Ensure.NotNull(rulesCode, "rulesCode");
             Ensure.NotNull(rulesCode.MetricsRoot, "rulesCode.MetricsRoot");
             Ensure.NotNull(rulesCode.MetricsRoot.metrics, "rulesCode.MetricsRoot.metrics");

--- a/Services/DataX.Config/DataX.Config/ConfigGeneration/Processor/S500_ResolveTimeWindow.cs
+++ b/Services/DataX.Config/DataX.Config/ConfigGeneration/Processor/S500_ResolveTimeWindow.cs
@@ -32,7 +32,7 @@ namespace DataX.Config.ConfigGeneration.Processor
             {
                 return "no gui input, skipped.";
             }
-            var rulesCode = flowToDeploy.GetAttachment<RulesCode>(GenerateTransformFile.AttachmentName_CodeGenObject);
+            var rulesCode = flowToDeploy.GetAttachment<RulesCode>(PrepareTransformFile.AttachmentName_CodeGenObject);
             Ensure.NotNull(rulesCode, "rulesCode");
             Ensure.NotNull(rulesCode.MetricsRoot, "rulesCode.MetricsRoot");
             Ensure.NotNull(rulesCode.MetricsRoot.metrics, "rulesCode.MetricsRoot.metrics");

--- a/Services/DataX.Config/DataX.Config/ConfigGeneration/Processor/S600_GenerateJobConfigBatch.cs
+++ b/Services/DataX.Config/DataX.Config/ConfigGeneration/Processor/S600_GenerateJobConfigBatch.cs
@@ -166,7 +166,7 @@ namespace DataX.Config.ConfigGeneration.Processor
                 lastProcessingTime = processingTime;
                 var processingTimeBasedOnInterval = NormalizeTimeBasedOnInterval(processingTime, batchProps.IntervalType, new TimeSpan());
                 var processingTimeBasedOnDelay = NormalizeTimeBasedOnInterval(processingTime, batchProps.IntervalType, delay);
-                JobConfig jc = await ScheduleSingleJob(job, destFolder, defaultJobConfig, isOneTime, interval, window, processingTimeBasedOnDelay, processingTimeBasedOnInterval, prefix).ConfigureAwait(false);
+                JobConfig jc = ScheduleSingleJob(job, destFolder, defaultJobConfig, isOneTime, interval, window, processingTimeBasedOnDelay, processingTimeBasedOnInterval, prefix);
                 jQueue.Add(jc);
             }
 
@@ -203,7 +203,7 @@ namespace DataX.Config.ConfigGeneration.Processor
         /// Schedule a batch job
         /// </summary>
         /// <returns></returns>
-        private async Task<JobConfig> ScheduleSingleJob(JobDeploymentSession job, string destFolder, JsonConfig defaultJobConfig, bool isOneTime, TimeSpan interval, TimeSpan window, DateTime processTime, DateTime scheduledTime, string prefix = "")
+        private JobConfig ScheduleSingleJob(JobDeploymentSession job, string destFolder, JsonConfig defaultJobConfig, bool isOneTime, TimeSpan interval, TimeSpan window, DateTime processTime, DateTime scheduledTime, string prefix = "")
         {
             var ps_s = processTime;
             var ps_e = processTime.Add(interval).AddMilliseconds(-1); //ENDTIME
@@ -224,7 +224,7 @@ namespace DataX.Config.ConfigGeneration.Processor
             destFolder = GetJobConfigFilePath(isOneTime, dateString, destFolder);
             var jc = new JobConfig
             {
-                Content = await GetBatchConfigContent(job, defaultJobConfig.ToString(), processStartTime, processEndTime).ConfigureAwait(false),
+                Content = GetBatchConfigContent(job, defaultJobConfig.ToString(), processStartTime, processEndTime),
                 FilePath = ResourcePathUtil.Combine(destFolder, job.Name + ".conf"),
                 Name = jobName,
                 SparkJobName = job.SparkJobName + suffix,
@@ -260,7 +260,7 @@ namespace DataX.Config.ConfigGeneration.Processor
         /// Get a batch job config
         /// </summary>
         /// <returns></returns>
-        private async Task<string> GetBatchConfigContent(JobDeploymentSession job, string content, string processStartTime, string processEndTime)
+        private static string GetBatchConfigContent(JobDeploymentSession job, string content, string processStartTime, string processEndTime)
         {
             var specsBackup = job.GetAttachment<InputBatchingSpec[]>(TokenName_InputBatching);
 

--- a/Services/DataX.Config/DataX.Config/ConfigGeneration/Processor/S610_GenerateTransformFile.cs
+++ b/Services/DataX.Config/DataX.Config/ConfigGeneration/Processor/S610_GenerateTransformFile.cs
@@ -40,7 +40,6 @@ namespace DataX.Config.ConfigGeneration.Processor
             return 610;
         }
 
-
         public override async Task<string> Process(FlowDeploymentSession flowToDeploy)
         {
             var jobs = flowToDeploy.GetJobs();
@@ -51,12 +50,9 @@ namespace DataX.Config.ConfigGeneration.Processor
 
             var config = flowToDeploy.Config;
 
-            var rulesCode = flowToDeploy.GetAttachment<RulesCode>(PrepareTransformFile.AttachmentName_CodeGenObject);
+            var rulesCode = flowToDeploy.GetAttachment<RulesCode>(AttachmentName_CodeGenObject);
             Ensure.NotNull(rulesCode, "rulesCode");
             
-            // Save the rulesCode object for downstream processing
-            flowToDeploy.SetAttachment(AttachmentName_CodeGenObject, rulesCode);
-
             var runtimeConfigBaseFolder = flowToDeploy.GetTokenString(PrepareJobConfigVariables.TokenName_RuntimeConfigFolder);
             Ensure.NotNull(runtimeConfigBaseFolder, "runtimeConfigBaseFolder");
 

--- a/Services/DataX.Config/DataX.Config/ConfigGeneration/Processor/S610_GenerateTransformFile.cs
+++ b/Services/DataX.Config/DataX.Config/ConfigGeneration/Processor/S610_GenerateTransformFile.cs
@@ -1,0 +1,75 @@
+﻿// *********************************************************************
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License
+// *********************************************************************
+using Newtonsoft.Json;
+using DataX.Config.Utility;
+using DataX.Contract;
+using DataX.Flow.CodegenRules;
+using System.Composition;
+using System.Linq;
+using System.Threading.Tasks;
+using DataX.Config.ConfigDataModel;
+
+namespace DataX.Config.ConfigGeneration.Processor
+{
+    /// <summary>
+    /// Produce the transform/query file section
+    /// </summary>
+    [Shared]
+    [Export(typeof(IFlowDeploymentProcessor))]
+    public class GenerateTransformFile : ProcessorBase
+    {
+        public const string TokenName_TransformFile = "processTransforms";
+        public const string AttachmentName_CodeGenObject = "rulesCode";
+
+        private ConfigGenConfiguration Configuration { get; }
+        private IKeyVaultClient KeyVaultClient { get; }
+        private IRuntimeConfigStorage RuntimeStorage { get; }
+
+        [ImportingConstructor]
+        public GenerateTransformFile(IKeyVaultClient keyvaultClient, IRuntimeConfigStorage runtimeStorage, ConfigGenConfiguration conf)
+        {
+            KeyVaultClient = keyvaultClient;
+            RuntimeStorage = runtimeStorage;
+            Configuration = conf;
+        }
+
+        public override int GetOrder()
+        {
+            return 610;
+        }
+
+
+        public override async Task<string> Process(FlowDeploymentSession flowToDeploy)
+        {
+            var jobs = flowToDeploy.GetJobs();
+            if (jobs == null || !jobs.Where(j => j.JobConfigs.Any()).Any())
+            {
+                return "no jobs, skipped";
+            }
+
+            var config = flowToDeploy.Config;
+
+            var rulesCode = flowToDeploy.GetAttachment<RulesCode>(PrepareTransformFile.AttachmentName_CodeGenObject);
+            Ensure.NotNull(rulesCode, "rulesCode");
+            
+            // Save the rulesCode object for downstream processing
+            flowToDeploy.SetAttachment(AttachmentName_CodeGenObject, rulesCode);
+
+            var runtimeConfigBaseFolder = flowToDeploy.GetTokenString(PrepareJobConfigVariables.TokenName_RuntimeConfigFolder);
+            Ensure.NotNull(runtimeConfigBaseFolder, "runtimeConfigBaseFolder");
+
+            var runtimeKeyVaultName = flowToDeploy.GetTokenString(PortConfigurationSettings.TokenName_RuntimeKeyVaultName);
+            Ensure.NotNull(runtimeKeyVaultName, "runtimeKeyVaultName");
+
+            var filePath = ResourcePathUtil.Combine(runtimeConfigBaseFolder, $"{config.Name}-combined.txt");
+            var transformFilePath = await RuntimeStorage.SaveFile(filePath, rulesCode.Code);
+            var secretName = $"{config.Name}-transform";
+            var transformFileSecret = await KeyVaultClient.SaveSecretAsync(runtimeKeyVaultName, secretName, transformFilePath, Configuration.TryGet(Constants.ConfigSettingName_SparkType, out string sparkType) ? sparkType : null);
+            flowToDeploy.SetStringToken(TokenName_TransformFile, transformFileSecret);
+
+            return "done";
+        }
+    }
+}

--- a/Services/DataX.Config/DataX.Config/ConfigGeneration/Processor/S630_GenerateSchemaFile.cs
+++ b/Services/DataX.Config/DataX.Config/ConfigGeneration/Processor/S630_GenerateSchemaFile.cs
@@ -22,8 +22,6 @@ namespace DataX.Config.ConfigGeneration.Processor
     [Export(typeof(IFlowDeploymentProcessor))]
     public class GenerateSchemaFile : ProcessorBase
     {
-        public const string TokenName_InputSchemaFilePath = "inputSchemaFilePath";
-
         [ImportingConstructor]
         public GenerateSchemaFile(IKeyVaultClient keyvaultClient, IRuntimeConfigStorage runtimeStorage, ConfigGenConfiguration conf)
         {
@@ -68,8 +66,8 @@ namespace DataX.Config.ConfigGeneration.Processor
             var filePath = ResourcePathUtil.Combine(runtimeConfigBaseFolder, "inputschema.json");
             var schemaFile = await RuntimeStorage.SaveFile(filePath, schema);
             var secretName = $"{config.Name}-inputschemafile";
-            var schemaFileSecret = await KeyVaultClient.SaveSecretAsync(runtimeKeyVaultName, secretName, schemaFile, Configuration.TryGet(Constants.ConfigSettingName_SparkType, out string sparkType) ? sparkType : null);
-            flowToDeploy.SetStringToken(TokenName_InputSchemaFilePath, schemaFileSecret);
+            var schemaFileSecret = flowToDeploy.GetTokenString(PrepareSchemaFile.TokenName_InputSchemaFilePath);
+            await KeyVaultClient.SaveSecretAsync(schemaFileSecret, schemaFile);
 
             return "done";
         }

--- a/Services/DataX.Config/DataX.Config/ConfigGeneration/Processor/S630_GenerateSchemaFile.cs
+++ b/Services/DataX.Config/DataX.Config/ConfigGeneration/Processor/S630_GenerateSchemaFile.cs
@@ -8,34 +8,47 @@ using DataX.Contract;
 using System;
 using System.Collections.Generic;
 using System.Composition;
+using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace DataX.Config.ConfigGeneration.Processor
 {
     /// <summary>
-    /// Produce the projection file section
+    /// Produce the schema file section
     /// </summary>
     [Shared]
     [Export(typeof(IFlowDeploymentProcessor))]
-    public class GenerateProjectionFile: ProcessorBase
+    public class GenerateSchemaFile : ProcessorBase
     {
-        public const string TokenName_ProjectionFiles = "processProjections";
+        public const string TokenName_InputSchemaFilePath = "inputSchemaFilePath";
 
         [ImportingConstructor]
-        public GenerateProjectionFile(IRuntimeConfigStorage runtimeStorage, IKeyVaultClient keyvaultClient, ConfigGenConfiguration conf)
+        public GenerateSchemaFile(IKeyVaultClient keyvaultClient, IRuntimeConfigStorage runtimeStorage, ConfigGenConfiguration conf)
         {
-            RuntimeStorage = runtimeStorage;
             KeyVaultClient = keyvaultClient;
+            RuntimeStorage = runtimeStorage;
             Configuration = conf;
         }
 
+        public override int GetOrder()
+        {
+            return 630;
+        }
+
         private ConfigGenConfiguration Configuration { get; }
-        private IRuntimeConfigStorage RuntimeStorage { get; }
         private IKeyVaultClient KeyVaultClient { get; }
-        
+        private IRuntimeConfigStorage RuntimeStorage { get; }
+
         public override async Task<string> Process(FlowDeploymentSession flowToDeploy)
         {
+            var jobs = flowToDeploy.GetJobs();
+            if (jobs == null || !jobs.Where(j => j.JobConfigs.Any()).Any())
+            {
+                return "no jobs, skipped";
+            }
+
             var config = flowToDeploy.Config;
             var guiConfig = config?.GetGuiConfig();
             if (guiConfig == null)
@@ -43,9 +56,8 @@ namespace DataX.Config.ConfigGeneration.Processor
                 return "no gui input, skipped.";
             }
 
-            var projectColumns = guiConfig.Input?.Properties?.NormalizationSnippet?.Trim('\t', ' ', '\r', '\n');
-            //TODO: make the hardcoded "Raw.*" configurable?
-            var finalProjections = string.IsNullOrEmpty(projectColumns) ? "Raw.*" : projectColumns;
+            var schema = guiConfig.Input?.Properties?.InputSchemaFile;
+            Ensure.NotNull(schema, "guiConfig.input.properties.inputschemafile");
 
             var runtimeConfigBaseFolder = flowToDeploy.GetTokenString(PrepareJobConfigVariables.TokenName_RuntimeConfigFolder);
             Ensure.NotNull(runtimeConfigBaseFolder, "runtimeConfigBaseFolder");
@@ -53,11 +65,11 @@ namespace DataX.Config.ConfigGeneration.Processor
             var runtimeKeyVaultName = flowToDeploy.GetTokenString(PortConfigurationSettings.TokenName_RuntimeKeyVaultName);
             Ensure.NotNull(runtimeKeyVaultName, "runtimeKeyVaultName");
 
-            var filePath = ResourcePathUtil.Combine(runtimeConfigBaseFolder, "projection.txt");
-            var savedFile = await RuntimeStorage.SaveFile(filePath, finalProjections);
-            var secretName = $"{config.Name}-projectionfile";
-            var savedSecretId = await KeyVaultClient.SaveSecretAsync(runtimeKeyVaultName, secretName, savedFile, Configuration.TryGet(Constants.ConfigSettingName_SparkType, out string sparkType) ? sparkType : null);
-            flowToDeploy.SetObjectToken(TokenName_ProjectionFiles, new string[] {savedSecretId});
+            var filePath = ResourcePathUtil.Combine(runtimeConfigBaseFolder, "inputschema.json");
+            var schemaFile = await RuntimeStorage.SaveFile(filePath, schema);
+            var secretName = $"{config.Name}-inputschemafile";
+            var schemaFileSecret = await KeyVaultClient.SaveSecretAsync(runtimeKeyVaultName, secretName, schemaFile, Configuration.TryGet(Constants.ConfigSettingName_SparkType, out string sparkType) ? sparkType : null);
+            flowToDeploy.SetStringToken(TokenName_InputSchemaFilePath, schemaFileSecret);
 
             return "done";
         }

--- a/Services/DataX.Config/DataX.Config/ConfigGeneration/Processor/S850_UpdateFlowMetrics.cs
+++ b/Services/DataX.Config/DataX.Config/ConfigGeneration/Processor/S850_UpdateFlowMetrics.cs
@@ -44,7 +44,7 @@ namespace DataX.Config.ConfigGeneration.Processor
             }
 
             // Get code gen data from earlier step
-            var rulesCode = flowToDeploy.GetAttachment<RulesCode>(GenerateTransformFile.AttachmentName_CodeGenObject);
+            var rulesCode = flowToDeploy.GetAttachment<RulesCode>(PrepareTransformFile.AttachmentName_CodeGenObject);
             Ensure.NotNull(rulesCode, "rulesCode");
             Ensure.NotNull(rulesCode.MetricsRoot, "rulesCode.MetricsRoot");
             Ensure.NotNull(rulesCode.MetricsRoot.metrics, "rulesCode.MetricsRoot.metrics");

--- a/Services/DataX.Config/DataX.Config/DataX.Config.csproj
+++ b/Services/DataX.Config/DataX.Config/DataX.Config.csproj
@@ -36,6 +36,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\DataX.Contract\DataX.Contract.csproj" />
     <ProjectReference Include="..\..\DataX.Flow\DataX.Flow.CodegenRules\DataX.Flow.CodegenRules.csproj" />
+    <ProjectReference Include="..\..\DataX.Utilities\DataX.Utility.KeyVault\DataX.Utility.KeyVault.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Services/DataX.Utilities/DataX.Utilities.Blob/BlobHelper.cs
+++ b/Services/DataX.Utilities/DataX.Utilities.Blob/BlobHelper.cs
@@ -153,9 +153,9 @@ namespace DataX.Utilities.Blob
             CloudBlobClient cloudBlobClient = storageAccount.CreateCloudBlobClient();
             CloudBlobContainer container = cloudBlobClient.GetContainerReference(containerName);
 
-            var filteredBlobs = container.ListBlobsSegmentedAsync(prefix: prefix, useFlatBlobListing: true, blobListingDetails: BlobListingDetails.None, maxResults: null, currentToken: null, options: null, operationContext: null).Result.Results.OfType<CloudBlockBlob>()
+            var filteredBlobs = await Task.Run(() => container.ListBlobsSegmentedAsync(prefix: prefix, useFlatBlobListing: true, blobListingDetails: BlobListingDetails.None, maxResults: null, currentToken: null, options: null, operationContext: null).Result.Results.OfType<CloudBlockBlob>()
                 .Where(b => ValidateBlobPath(blobPathPattern, b.Uri.ToString()) && b.Properties.Length > 0 && ValidateJson(b.DownloadTextAsync().Result))
-                .OrderByDescending(m => m.Properties.LastModified).ToList().Take(blobCount);
+                .OrderByDescending(m => m.Properties.LastModified).ToList().Take(blobCount)).ConfigureAwait(false);
 
             List<string> blobContents = new List<string>();
 

--- a/Services/DataX.Utilities/DataX.Utilities.Blob/BlobHelper.cs
+++ b/Services/DataX.Utilities/DataX.Utilities.Blob/BlobHelper.cs
@@ -152,10 +152,12 @@ namespace DataX.Utilities.Blob
             CloudStorageAccount storageAccount = CloudStorageAccount.Parse(connectionString);
             CloudBlobClient cloudBlobClient = storageAccount.CreateCloudBlobClient();
             CloudBlobContainer container = cloudBlobClient.GetContainerReference(containerName);
+            
+            var allBlobs = await container.ListBlobsSegmentedAsync(prefix: prefix, useFlatBlobListing: true, blobListingDetails: BlobListingDetails.None, maxResults: null, currentToken: null, options: null, operationContext: null).ConfigureAwait(false);
 
-            var filteredBlobs = await Task.Run(() => container.ListBlobsSegmentedAsync(prefix: prefix, useFlatBlobListing: true, blobListingDetails: BlobListingDetails.None, maxResults: null, currentToken: null, options: null, operationContext: null).Result.Results.OfType<CloudBlockBlob>()
+            var filteredBlobs = allBlobs.Results.OfType<CloudBlockBlob>()
                 .Where(b => ValidateBlobPath(blobPathPattern, b.Uri.ToString()) && b.Properties.Length > 0 && ValidateJson(b.DownloadTextAsync().Result))
-                .OrderByDescending(m => m.Properties.LastModified).ToList().Take(blobCount)).ConfigureAwait(false);
+                .OrderByDescending(m => m.Properties.LastModified).ToList().Take(blobCount);
 
             List<string> blobContents = new List<string>();
 

--- a/Services/DataX.Utilities/DataX.Utilities.EventHub/DataX.Utilities.EventHub.csproj
+++ b/Services/DataX.Utilities/DataX.Utilities.EventHub/DataX.Utilities.EventHub.csproj
@@ -23,7 +23,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.11" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.19" />
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="0.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
We don't need to generate Transform, Projection and Schema files when there is no job to deploy so the following will be executed after GenerateJobConfig and GenerateJobConfigBatch.
GenerateTransformFile
GenerateProjectionFile
GenerateSchemaFile