### PR TITLE
ARM: assign the writer role to the service AAD app

### DIFF
--- a/DeploymentCloud/Deployment.Common/Admin/adminsteps.parameters.txt
+++ b/DeploymentCloud/Deployment.Common/Admin/adminsteps.parameters.txt
@@ -11,3 +11,7 @@ clientAppId=$clientAppId
 
 # ResourceGroupName to generate resources 
 resourceGroupName=$resourceGroup
+
+# Role Names
+# Writer can manage flows
+writerRole=$writerRole

--- a/DeploymentCloud/Deployment.Common/Helpers/UtilityModule.psm1
+++ b/DeploymentCloud/Deployment.Common/Helpers/UtilityModule.psm1
@@ -564,7 +564,7 @@ function Set-AzureAADAccessControl([string]$AppId) {
     $ErrorActionPreference = "stop"
 }
 
-function Set-AzureAADApiPermission([string]$ServiceAppId, [string]$ClientAppId) {
+function Set-AzureAADApiPermission([string]$ServiceAppId, [string]$ClientAppId, [string]$RoleId) {
     $ErrorActionPreference = "SilentlyContinue"
 
     Write-Host -ForegroundColor Yellow  "Setting up App Api Permissions. This requires the subscription admin privilege. If this fails, please refer to the manual steps and ask a subscription admin"
@@ -572,9 +572,11 @@ function Set-AzureAADApiPermission([string]$ServiceAppId, [string]$ClientAppId) 
     $aadCommandId = "00000002-0000-0000-c000-000000000000"
     $permissionId = "311a71cc-e848-46a1-bdf8-97ff7156d8e6"
     
+    az ad app permission add --id $ServiceAppId --api $ServiceAppId --api-permissions $RoleId=Role > $null 2>&1
     az ad app permission add --id $ServiceAppId --api $aadCommandId --api-permissions $permissionId=Scope > $null 2>&1
     az ad app permission add --id $ClientAppId --api $aadCommandId --api-permissions $permissionId=Scope > $null 2>&1
     az ad app permission add --id $ClientAppId --api $ServiceAppId --api-permissions $ServiceAppPermId=Scope > $null 2>&1
+    az ad app permission grant --id $ServiceAppId --api $ServiceAppId --scope $RoleId > $null 2>&1
     az ad app permission grant --id $ServiceAppId --api $aadCommandId --scope $permissionId > $null 2>&1
     az ad app permission grant --id $ClientAppId --api $aadCommandId --scope $permissionId > $null 2>&1
     az ad app permission grant --id $ClientAppId --api $ServiceAppId --scope $ServiceAppPermId > $null 2>&1

--- a/DeploymentCloud/Deployment.Common/Helpers/UtilityModule.psm1
+++ b/DeploymentCloud/Deployment.Common/Helpers/UtilityModule.psm1
@@ -564,7 +564,7 @@ function Set-AzureAADAccessControl([string]$AppId) {
     $ErrorActionPreference = "stop"
 }
 
-function Set-AzureAADApiPermission([string]$ServiceAppId, [string]$ClientAppId, [string]$RoleId) {
+function Set-AzureAADApiPermission([string]$ServiceAppId, [string]$ClientAppId, [string]$RoleName) {
     $ErrorActionPreference = "SilentlyContinue"
 
     Write-Host -ForegroundColor Yellow  "Setting up App Api Permissions. This requires the subscription admin privilege. If this fails, please refer to the manual steps and ask a subscription admin"
@@ -572,11 +572,24 @@ function Set-AzureAADApiPermission([string]$ServiceAppId, [string]$ClientAppId, 
     $aadCommandId = "00000002-0000-0000-c000-000000000000"
     $permissionId = "311a71cc-e848-46a1-bdf8-97ff7156d8e6"
     
-    az ad app permission add --id $ServiceAppId --api $ServiceAppId --api-permissions $RoleId=Role > $null 2>&1
+    if ($RoleName) {
+        $appRoles =  az ad app show --id $ServiceAppId --query appRoles | ConvertFrom-Json
+
+        $role = $appRoles | Where-Object { $_.Value -match $RoleName }
+        if ($role) {
+            $roleId = $role.Id
+            az ad app permission add --id $ServiceAppId --api $ServiceAppId --api-permissions $roleId=Role > $null 2>&1
+            az ad app permission grant --id $ServiceAppId --api $ServiceAppId --scope $roleId > $null 2>&1
+        }
+        else 
+        {
+            Write-Host -ForegroundColor Red  "$RoleName is not defined in the app $ServiceAppId"
+        }
+    }
+    
     az ad app permission add --id $ServiceAppId --api $aadCommandId --api-permissions $permissionId=Scope > $null 2>&1
     az ad app permission add --id $ClientAppId --api $aadCommandId --api-permissions $permissionId=Scope > $null 2>&1
     az ad app permission add --id $ClientAppId --api $ServiceAppId --api-permissions $ServiceAppPermId=Scope > $null 2>&1
-    az ad app permission grant --id $ServiceAppId --api $ServiceAppId --scope $RoleId > $null 2>&1
     az ad app permission grant --id $ServiceAppId --api $aadCommandId --scope $permissionId > $null 2>&1
     az ad app permission grant --id $ClientAppId --api $aadCommandId --scope $permissionId > $null 2>&1
     az ad app permission grant --id $ClientAppId --api $ServiceAppId --scope $ServiceAppPermId > $null 2>&1

--- a/DeploymentCloud/Deployment.Common/deployResources.ps1
+++ b/DeploymentCloud/Deployment.Common/deployResources.ps1
@@ -227,12 +227,15 @@ function Get-Tokens {
 }
 
 # Get appRole definition
-function Create-AppRole([string] $Name, [string] $Description) {
+function Create-AppRole([string] $Name, [string] $AppName, [string] $guid, [string] $Description) {
     $appRole = New-Object Microsoft.Open.AzureAD.Model.AppRole
     $appRole.AllowedMemberTypes = New-Object System.Collections.Generic.List[string]
     $appRole.AllowedMemberTypes.Add("User");
+    if (($Name -eq $writerRole) -and ($AppName -eq $serviceAppName)) {
+        $appRole.AllowedMemberTypes.Add("Application");
+    }
     $appRole.DisplayName = $Name
-    $appRole.Id = New-Guid
+    $appRole.Id = $guid
     $appRole.IsEnabled = $true
     $appRole.Description = $Description
     $appRole.Value = $Name
@@ -241,8 +244,10 @@ function Create-AppRole([string] $Name, [string] $Description) {
 
 # Add appRoles to AAD app
 function Set-AzureAADAppRoles([string]$AppName) {
-    $role_r = Create-AppRole -Name $readerRole -Description $readerRole + " have ability to view flows"
-    $role_w = Create-AppRole -Name $writerRole -Description $writerRole + " can manage flows"
+    $newGuid_reader = New-Guid
+    $newGuid_writer = New-Guid
+    $role_r = Create-AppRole -Name $readerRole -AppName $AppName -guid $newGuid_reader -Description $readerRole + " have ability to view flows"
+    $role_w = Create-AppRole -Name $writerRole -AppName $AppName -guid $newGuid_writer -Description $writerRole + " can manage flows"
     $roles = @($role_r, $role_W)
     
     $app = Get-AzureADApplication -Filter "DisplayName eq '$AppName'"
@@ -265,6 +270,8 @@ function Set-AzureAADAppRoles([string]$AppName) {
     
         Set-AzureADApplication -ObjectId $app.ObjectId -AppRoles $app.AppRoles
     }
+    
+    return $newGuid_writer
 }
 
 # Add user with appRoles to service principal
@@ -850,13 +857,13 @@ Set-AzureAADAppCert -AppName $serviceAppName
 $azureADAppSecretValue = $azureADAppSecret.Value 
 $azureADAppSecretConfiggenValue = $azureADAppSecretConfiggen.Value
 
-Set-AzureAADAccessControl -AppId $azureADApplicationConfiggenApplicationId
-Set-AzureAADApiPermission -ServiceAppId $azureADApplicationConfiggenApplicationId -ClientAppId $azureADApplicationApplicationId
-
 Set-AzureAADAppRoles -AppName $clientAppName
-Set-AzureAADAppRoles -AppName $serviceAppName
+$serviceRoleId = Set-AzureAADAppRoles -AppName $serviceAppName
 Add-UserAppRole -AppName $clientAppName
 Add-UserAppRole -AppName $serviceAppName
+
+Set-AzureAADAccessControl -AppId $azureADApplicationConfiggenApplicationId
+Set-AzureAADApiPermission -ServiceAppId $azureADApplicationConfiggenApplicationId -ClientAppId $azureADApplicationApplicationId -RoleId $serviceRoleId
 
 if($serviceFabricCreation -eq 'y') {
     Write-Host -ForegroundColor Green "Deploying resources (4/16 steps): A Service fabric cluster will be deployed"

--- a/DeploymentCloud/Deployment.DataX/adminSteps.ps1
+++ b/DeploymentCloud/Deployment.DataX/adminSteps.ps1
@@ -41,6 +41,6 @@ Write-Host "Signing in '$tenantId'"
 az login --tenant $tenantId
 
 Set-AzureAADAccessControl -AppId $serviceAppId
-Set-AzureAADApiPermission -ServiceAppId $serviceAppId -ClientAppId $clientAppId
+Set-AzureAADApiPermission -ServiceAppId $serviceAppId -ClientAppId $clientAppId -RoleName $writerRole
 
 Exit 0


### PR DESCRIPTION
Assigning the writer role to the service AAD app. This is needed for the interservice communication api calls.