### PR TITLE
Adding steps for a new JobRunner job calling into ScenarioTester. 

### DIFF
--- a/Services/JobRunner/AppConfig.cs
+++ b/Services/JobRunner/AppConfig.cs
@@ -35,5 +35,13 @@ namespace JobRunner
         public string SecretKey { get; set; }
         public string BlobConnectionString { get; set; }
         public string BlobUri { get; set; }
+        public string EvenHubConnectionString { get; set; }
+        public string EventHubName { get; set; }
+        public string IsIotHub { get; set; }
+        public string Seconds { get; set; }
+        public string FlowName { get; set; }
+        public string NormalizationSnippet { get; set; }
+        public string DatabricksToken { get; set; }
+        public string SparkType { get; set; }
     }
 }

--- a/Services/JobRunner/AppConfig.cs
+++ b/Services/JobRunner/AppConfig.cs
@@ -30,7 +30,7 @@ namespace JobRunner
         public string ServiceKeyVaultName { get; set; }
         public string AppInsightsIntrumentationKey { get; set; }
         public string MicrosoftAuthority { get; set; }
-        public string DataHubIdentifier { get; set; }
+        public string ApplicationIdentifierUri { get; set; }
         public string ApplicationId { get; set; }
         public string SecretKey { get; set; }
         public string BlobConnectionString { get; set; }

--- a/Services/JobRunner/JobRunner.cs
+++ b/Services/JobRunner/JobRunner.cs
@@ -31,7 +31,7 @@ namespace JobRunner
         // We have a distinct primary and test queue to compartmentalize runners.  The target queue client for this runner is set in the configuration.
         private readonly IQueueClient _primaryQueueClient;
         private readonly IQueueClient _testQueueClient;
-        private const int _Minutes = 10;
+        private const int _Minutes = 20;
 
         private readonly string _activeQueueName;
         private IQueueClient _ActiveQueueClient

--- a/Services/JobRunner/JobRunner.cs
+++ b/Services/JobRunner/JobRunner.cs
@@ -31,6 +31,7 @@ namespace JobRunner
         // We have a distinct primary and test queue to compartmentalize runners.  The target queue client for this runner is set in the configuration.
         private readonly IQueueClient _primaryQueueClient;
         private readonly IQueueClient _testQueueClient;
+        private const int _Minutes = 10;
 
         private readonly string _activeQueueName;
         private IQueueClient _ActiveQueueClient
@@ -277,20 +278,20 @@ namespace JobRunner
                 new TimeSpan(0, 5, 0),
                 useTestQueue: true).Wait();
 
-            // run DataX Schema and Query job every 15 minutes
+            // run DataX Schema and Query job every few minutes
             this.ScheduledJobTable.CreateOrUpdateScheduledJobAsync(
                 "DataXSchemaAndQueryJob",
                 GetJobKey<DataXSchemaAndQueryJob>(),
                 new DateTime(2019, 1, 1, 1, 1, 1),
-                new TimeSpan(0, 15, 0),
+                new TimeSpan(0, _Minutes, 0),
                 useTestQueue: true).Wait();
 
-            //run DataX mainline job every 15 minutes.
+            //run DataX mainline job every few minutes.
             this.ScheduledJobTable.CreateOrUpdateScheduledJobAsync(
                 "DataXDeployJob",
                 GetJobKey<DataXDeployJob>(),
                 new DateTime(2019, 1, 1, 1, 1, 1),
-                new TimeSpan(0, 15, 0),
+                new TimeSpan(0, _Minutes, 0),
                 useTestQueue: true).Wait();
         }
 

--- a/Services/JobRunner/JobRunner.cs
+++ b/Services/JobRunner/JobRunner.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using System.Composition;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -171,8 +172,9 @@ namespace JobRunner
         /// <returns>A boolean of if this is a job or not.</returns>
         private bool IsJobType(Type type)
         {
+            var attr = Attribute.GetCustomAttribute(type, typeof(CompilerGeneratedAttribute));            
             return string.Equals(type.Namespace, "JobRunner.Jobs", StringComparison.Ordinal)
-                    && !type.IsInterface;
+                    && !type.IsInterface && attr==null;
         }
 
         /// <summary>
@@ -275,12 +277,20 @@ namespace JobRunner
                 new TimeSpan(0, 5, 0),
                 useTestQueue: true).Wait();
 
-            // run DataX mainline job every 10 minutes.
+            // run DataX Schema and Query job every 15 minutes
+            this.ScheduledJobTable.CreateOrUpdateScheduledJobAsync(
+                "DataXSchemaAndQueryJob",
+                GetJobKey<DataXSchemaAndQueryJob>(),
+                new DateTime(2019, 1, 1, 1, 1, 1),
+                new TimeSpan(0, 15, 0),
+                useTestQueue: true).Wait();
+
+            //run DataX mainline job every 15 minutes.
             this.ScheduledJobTable.CreateOrUpdateScheduledJobAsync(
                 "DataXDeployJob",
                 GetJobKey<DataXDeployJob>(),
                 new DateTime(2019, 1, 1, 1, 1, 1),
-                new TimeSpan(0, 10, 0),
+                new TimeSpan(0, 15, 0),
                 useTestQueue: true).Wait();
         }
 

--- a/Services/JobRunner/Jobs/DataXSchemaAndQueryJob.cs
+++ b/Services/JobRunner/Jobs/DataXSchemaAndQueryJob.cs
@@ -17,7 +17,7 @@ using Newtonsoft.Json;
 namespace JobRunner.Jobs
 {
     /// <summary>
-    /// Runs through a steel thread scenario for a DataX every 10 minutes to ensure DataX E2E works for Interactive query experience, schemaGen and Live data service.
+    /// Runs through a steel thread scenario for a DataX every few minutes to ensure DataX E2E works for Interactive query experience, SchemaGen and Live data service.
     /// </summary>
     public class DataXSchemaAndQueryJob : IJob
     {
@@ -45,9 +45,8 @@ namespace JobRunner.Jobs
         /// </summary>
         /// <returns></returns>
         public async Task RunAsync()
-        {
-            var server = _config.ServiceUrl;
-            if (string.IsNullOrWhiteSpace(server))
+        {            
+            if (string.IsNullOrWhiteSpace(_config.ServiceUrl))
             {
                 string errorMessage = "Server URL is not available.";
                 _logger.LogError(_scenario.Description, "JobRunner ScenarioTester", new Dictionary<string, string>() { { "scenario.errorMessage", errorMessage } });
@@ -59,7 +58,7 @@ namespace JobRunner.Jobs
             {
                 context[Context.ServiceUrl] = _config.ServiceUrl;
                 context[Context.ApplicationId] = KeyVault.GetSecretFromKeyvault(_config.ApplicationId);
-                context[Context.DataHubIdentifier] = _config.DataHubIdentifier;
+                context[Context.ApplicationIdentifierUri] = _config.ApplicationIdentifierUri;
                 context[Context.SecretKey] = KeyVault.GetSecretFromKeyvault(_config.SecretKey);
                 context[Context.MicrosoftAuthority] = _config.MicrosoftAuthority;
                 context[Context.EventhubConnectionString] = KeyVault.GetSecretFromKeyvault(_config.EvenHubConnectionString);

--- a/Services/JobRunner/Jobs/DataXSchemaAndQueryJob.cs
+++ b/Services/JobRunner/Jobs/DataXSchemaAndQueryJob.cs
@@ -1,0 +1,139 @@
+﻿// *********************************************************************
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License
+// *********************************************************************
+
+using ScenarioTester;
+using System;
+using DataX.ServerScenarios;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+using System.Linq;
+using DataX.Utilities.KeyVault;
+using DataX.Utility.Blob;
+using Newtonsoft.Json;
+
+namespace JobRunner.Jobs
+{
+    /// <summary>
+    /// Runs through a steel thread scenario for a DataX every 10 minutes to ensure DataX E2E works for Interactive query experience, schemaGen and Live data service.
+    /// </summary>
+    public class DataXSchemaAndQueryJob : IJob
+    {
+        private readonly ScenarioDescription _scenario;
+        private readonly AppConfig _config;
+        private readonly ILogger _logger;
+        private readonly int _scenarioCount = 1;
+
+        public DataXSchemaAndQueryJob(AppConfig config, ILogger logger)
+        {
+            _config = config;
+            _logger = logger;
+
+            _scenario = new ScenarioDescription("DataXSchemaAndQuery",
+                DataXHost.AcquireToken,
+                DataXHost.InferSchema,
+                DataXHost.InitializeKernel,
+                DataXHost.RefreshSampleAndKernel,
+                DataXHost.RefreshKernel,
+                DataXHost.RefreshSample
+               );
+        }
+        /// <summary>
+        /// This is the method that gets called when the job starts running
+        /// </summary>
+        /// <returns></returns>
+        public async Task RunAsync()
+        {
+            var server = _config.ServiceUrl;
+            if (string.IsNullOrWhiteSpace(server))
+            {
+                string errorMessage = "Server URL is not available.";
+                _logger.LogError(_scenario.Description, "JobRunner ScenarioTester", new Dictionary<string, string>() { { "scenario.errorMessage", errorMessage } });
+
+                throw new InvalidOperationException(errorMessage);
+            }
+
+            using (var context = new ScenarioContext())
+            {
+                context[Context.ServiceUrl] = _config.ServiceUrl;
+                context[Context.ApplicationId] = KeyVault.GetSecretFromKeyvault(_config.ApplicationId);
+                context[Context.DataHubIdentifier] = _config.DataHubIdentifier;
+                context[Context.SecretKey] = KeyVault.GetSecretFromKeyvault(_config.SecretKey);
+                context[Context.MicrosoftAuthority] = _config.MicrosoftAuthority;
+                context[Context.EventhubConnectionString] = KeyVault.GetSecretFromKeyvault(_config.EvenHubConnectionString);
+                context[Context.EventHubName] = _config.EventHubName;
+                context[Context.IsIotHub] = _config.IsIotHub;
+                context[Context.Seconds] = _config.Seconds;
+                context[Context.FlowName] = _config.FlowName;
+                if (_config.SparkType == "databricks")
+                {
+                    context[Context.DataBricksToken] = KeyVault.GetSecretFromKeyvault(_config.DatabricksToken);
+                }
+                else
+                {
+                    context[Context.DataBricksToken] = "";
+                }
+                context[Context.SparkType] = _config.SparkType;
+                context[Context.FlowConfigContent] = await Task.Run(() => BlobUtility.GetBlobContent(KeyVault.GetSecretFromKeyvault(_config.BlobConnectionString), _config.BlobUri));
+                context[Context.NormalizationSnippet] = JsonConvert.SerializeObject(_config.NormalizationSnippet);
+                context[Context.KernelId] = "";
+
+                using (_logger.BeginScope<IReadOnlyCollection<KeyValuePair<string, object>>>(
+                    new Dictionary<string, object> {
+                        { "scenario.Description", _scenario.Description },
+                        { "scenarioCount", _scenarioCount.ToString() },
+                        { "scenario.Steps", $"[{string.Join(", ", _scenario.Steps.Select(s => s.Method.Name))}]" }
+                    }))
+                {
+                    // do actual logging inside the scope. All logs inside this will have the properties from the Dictionary used in begin scope.
+                    _logger.LogInformation("JobRunner ScenarioTester: " + _scenario.Description);
+
+                }
+
+                var results = await ScenarioResult.RunAsync(_scenario, context, _scenarioCount);
+                int iterationCount = 0;
+
+                foreach (var result in results)
+                {
+                    string scenarioResult = result.Failed ? "failed" : "succeeded";
+
+                    // log failed steps.
+                    foreach (var stepResult in result.StepResults.Where(r => !r.Success))
+                    {
+                        using (_logger.BeginScope<IReadOnlyCollection<KeyValuePair<string, object>>>(
+                            new Dictionary<string, object> {
+                                { "Scenario iteration", $"Scenario iteration {_scenario.Description}.{iterationCount} " },
+                                { "ScenarioResult length", scenarioResult.Length}
+                            }))
+                        {
+                            // do actual logging inside the scope. All logs inside this will have the properties from the Dictionary used in begin scope.
+                            _logger.LogInformation(_scenario.Description);
+
+                        }
+
+                        if (stepResult.Exception != null)
+                        {
+                            _logger.LogError(stepResult.Exception, _scenario.Description);
+                        }
+                        _logger.LogError(stepResult.Value);
+                    }
+
+                    iterationCount++;
+                }
+
+                //emit metric on how many parallel executions passed.
+                using (_logger.BeginScope<IReadOnlyCollection<KeyValuePair<string, object>>>(
+                    new Dictionary<string, object> {
+                        { $"SuccessRate:{_scenario.Description}", $"{(long)((double)results.Count(r => !r.Failed) / _scenarioCount * 100.0)}" }
+                    }))
+                {
+                    // do actual logging inside the scope. All logs inside this will have the properties from the Dictionary used in begin scope.
+                    _logger.LogInformation(_scenario.Description);
+
+                }
+            }
+        }
+    }
+}

--- a/Services/JobRunnerWebJob/appsettings.Development.json
+++ b/Services/JobRunnerWebJob/appsettings.Development.json
@@ -7,12 +7,20 @@
     "ActiveQueueName": "",
     "ServiceUrl": "",
     "ServiceKeyVaultName": "",
-    "AppInsightsIntrumentation": "",
+    "AppInsightsIntrumentationKey": "",
     "MicrosoftAuthority": "",
     "DataHubIdentifier": "",
     "ApplicationId": "",
     "SecretKey": "",
     "BlobConnectionString": "",
-    "BlobUri": ""
+    "BlobUri": "",
+    "EvenHubConnectionString": "",
+    "EventHubName": "",
+    "IsIotHub": "",
+    "Seconds": "",
+    "FlowName": "",
+    "NormalizationSnippet": "",
+    "DatabricksToken": "",
+    "SparkType": ""
   }
 }

--- a/Services/JobRunnerWebJob/appsettings.Development.json
+++ b/Services/JobRunnerWebJob/appsettings.Development.json
@@ -9,7 +9,7 @@
     "ServiceKeyVaultName": "",
     "AppInsightsIntrumentationKey": "",
     "MicrosoftAuthority": "",
-    "DataHubIdentifier": "",
+    "ApplicationIdentifierUri": "",
     "ApplicationId": "",
     "SecretKey": "",
     "BlobConnectionString": "",

--- a/Services/JobRunnerWebJob/appsettings.json
+++ b/Services/JobRunnerWebJob/appsettings.json
@@ -13,6 +13,14 @@
     "ApplicationId": "",
     "SecretKey": "",
     "BlobConnectionString": "",
-    "BlobUri": ""
+    "BlobUri": "",
+    "EvenHubConnectionString": "",
+    "EventHubName": "",
+    "IsIotHub": "",
+    "Seconds": "",
+    "FlowName": "",
+    "NormalizationSnippet": "",
+    "DatabricksToken": "",
+    "SparkType": ""
   }
 }

--- a/Services/JobRunnerWebJob/appsettings.json
+++ b/Services/JobRunnerWebJob/appsettings.json
@@ -9,7 +9,7 @@
     "ServiceKeyVaultName": "",
     "AppInsightsIntrumentation": "",
     "MicrosoftAuthority": "",
-    "DataHubIdentifier": "",
+    "ApplicationIdentifierUri": "",
     "ApplicationId": "",
     "SecretKey": "",
     "BlobConnectionString": "",

--- a/Tests/DataXScenarios/DataXScenarios/Context.cs
+++ b/Tests/DataXScenarios/DataXScenarios/Context.cs
@@ -14,7 +14,7 @@ namespace DataX.ServerScenarios
         public const string ServiceUrl = "server";
         public const string AuthToken = "authToken";
         public const string MicrosoftAuthority = "microsoftAuthority";
-        public const string DataHubIdentifier = "dataHubIdentifier";
+        public const string ApplicationIdentifierUri = "applicationIdentifierUri";
         public const string ApplicationId = "applicationId";
         public const string ApplicationName = "applicationName";
         public const string SecretKey = "secretKey";

--- a/Tests/DataXScenarios/DataXScenarios/Context.cs
+++ b/Tests/DataXScenarios/DataXScenarios/Context.cs
@@ -25,5 +25,17 @@ namespace DataX.ServerScenarios
         public const string RestartJobsName = "restartJobsName";
         public const string FlowConfig = "flowConfig";
         public const string FlowConfigContent = "flowConfigContent";
+        public const string InputSchema = "InputSchema";
+        public const string EventhubConnectionString = "eventhubConnectionString";
+        public const string EventHubName = "eventHubName";
+        public const string IsIotHub = "isIotHub";
+        public const string InferSchemaInputJson = "inferSchemaInputJson";
+        public const string Seconds = "seconds";
+        public const string KernelId = "kernelId";
+        public const string InitializeKernelJson = "initializeKernelJson";
+        public const string NormalizationSnippet = "normalizationSnippet";
+        public const string DataBricksToken = "dataBricksToken";
+        public const string SparkType = "sparkType";
+        public const string StartJobName = "startJobName";
     }
 }

--- a/Tests/DataXScenarios/DataXScenarios/Helper.cs
+++ b/Tests/DataXScenarios/DataXScenarios/Helper.cs
@@ -1,0 +1,25 @@
+﻿// *********************************************************************
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License
+// *********************************************************************
+using DataX.ServerScenarios;
+using ScenarioTester;
+
+namespace DataXScenarios
+{
+    /// <summary>
+    /// Helper class for the scnearios
+    /// </summary>
+    public class Helper
+    {
+        /// <summary>
+        /// Creating a helper function for constructing the InitializeKernelJson
+        /// </summary>
+        /// <param name="context">ScenarioContext</param>
+        /// <returns></returns>
+        public string GetInitializeKernelJson(ScenarioContext context)
+        {
+            return $"{{\"name\": \"{context[Context.FlowName] as string}\", \"userName\": \"{context[Context.FlowName] as string}\", \"eventhubConnectionString\": \"{context[Context.EventhubConnectionString] as string}\", \"eventHubNames\": \"{context[Context.EventHubName] as string}\", \"inputType\": \"iothub\", \"inputSchema\": {context[Context.InputSchema] as string}, \"kernelId\": \"{context[Context.KernelId] as string}\", \"normalizationSnippet\": {context[Context.NormalizationSnippet] as string}, \"databricksToken\": \"{context[Context.DataBricksToken] as string}\"}}";
+        }
+    }
+}

--- a/Tests/DataXScenarios/DataXScenarios/InteractiveQueryAndSchemaGenScenarios.cs
+++ b/Tests/DataXScenarios/DataXScenarios/InteractiveQueryAndSchemaGenScenarios.cs
@@ -8,6 +8,7 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.Text;
 using System.Threading.Tasks;
+using DataXScenarios;
 
 namespace DataX.ServerScenarios
 {
@@ -36,9 +37,9 @@ namespace DataX.ServerScenarios
         public static StepResult InitializeKernel(ScenarioContext context)
         {
             var baseAddress = $"{context[Context.ServiceUrl] as string}/api/DataX.Flow/Flow.InteractiveQueryService/kernel";
-            
-            context[Context.InitializeKernelJson] = $"{{\"name\": \"{context[Context.FlowName] as string}\", \"userName\": \"{context[Context.FlowName] as string}\", \"eventhubConnectionString\": \"{context[Context.EventhubConnectionString] as string}\", \"eventHubNames\": \"{context[Context.EventHubName] as string}\", \"inputType\": \"iothub\", \"inputSchema\": {context[Context.InputSchema] as string}, \"kernelId\": \"{context[Context.KernelId] as string}\", \"normalizationSnippet\": {context[Context.NormalizationSnippet] as string}, \"databricksToken\": \"{context[Context.DataBricksToken] as string}\"}}";
-            
+
+            Helper helper = new Helper();
+            context[Context.InitializeKernelJson] = helper.GetInitializeKernelJson(context);
             string jsonResult = Request.Post(baseAddress,
                     RequestContent.EncodeAsJson(
                         JObject.Parse(context[Context.InitializeKernelJson] as string)),
@@ -47,8 +48,9 @@ namespace DataX.ServerScenarios
             dynamic result = JObject.Parse(jsonResult);
             context[Context.KernelId] = (string)result.result.result;
 
-            context[Context.InitializeKernelJson] = $"{{\"name\": \"{context[Context.FlowName] as string}\", \"userName\": \"{context[Context.FlowName] as string}\", \"eventhubConnectionString\": \"{context[Context.EventhubConnectionString] as string}\", \"eventHubNames\": \"{context[Context.EventHubName] as string}\", \"inputType\": \"iothub\", \"inputSchema\": {context[Context.InputSchema] as string}, \"kernelId\": \"{context[Context.KernelId] as string}\", \"normalizationSnippet\": {context[Context.NormalizationSnippet] as string}, \"databricksToken\": \"{context[Context.DataBricksToken] as string}\"}}";
-            
+            context[Context.InitializeKernelJson] = helper.GetInitializeKernelJson(context);
+
+
             return new StepResult(!(string.IsNullOrWhiteSpace(context[Context.KernelId] as string) && (string) result.result.message==""),
                 nameof(InitializeKernel),
                 $"Initialize a kernel '{context[Context.KernelId]}' ");
@@ -90,7 +92,7 @@ namespace DataX.ServerScenarios
         public static StepResult RefreshSampleAndKernel(ScenarioContext context)
         {
             var baseAddress = $"{context[Context.ServiceUrl] as string}/api/DataX.Flow/Flow.LiveDataService/inputdata/refreshsampleandkernel";
-            context[Context.InitializeKernelJson] = $"{{\"name\": \"{context[Context.FlowName] as string}\", \"userName\": \"{context[Context.FlowName] as string}\", \"eventhubConnectionString\": \"{context[Context.EventhubConnectionString] as string}\", \"eventHubNames\": \"{context[Context.EventHubName] as string}\", \"inputType\": \"iothub\", \"inputSchema\": {context[Context.InputSchema] as string}, \"kernelId\": \"{context[Context.KernelId] as string}\", \"normalizationSnippet\": {context[Context.NormalizationSnippet] as string}, \"databricksToken\": \"{context[Context.DataBricksToken] as string}\"}}";
+            context[Context.InitializeKernelJson] = new Helper().GetInitializeKernelJson(context);
 
             string jsonResult = Request.Post(baseAddress,
                     RequestContent.EncodeAsJson(

--- a/Tests/DataXScenarios/DataXScenarios/InteractiveQueryAndSchemaGenScenarios.cs
+++ b/Tests/DataXScenarios/DataXScenarios/InteractiveQueryAndSchemaGenScenarios.cs
@@ -58,8 +58,7 @@ namespace DataX.ServerScenarios
         public static StepResult RefreshKernel(ScenarioContext context)
         {
             var baseAddress = $"{context[Context.ServiceUrl] as string}/api/DataX.Flow/Flow.InteractiveQueryService/kernel/refresh";
-            context[Context.InitializeKernelJson] = $"{{\"name\": \"{context[Context.FlowName] as string}\", \"userName\": \"{context[Context.FlowName] as string}\", \"eventhubConnectionString\": \"{context[Context.EventhubConnectionString] as string}\", \"eventHubNames\": \"{context[Context.EventHubName] as string}\", \"inputType\": \"iothub\", \"inputSchema\": {context[Context.InputSchema] as string}, \"kernelId\": \"{context[Context.KernelId] as string}\", \"normalizationSnippet\": {context[Context.NormalizationSnippet] as string}, \"databricksToken\": \"{context[Context.DataBricksToken] as string}\"}}";
-
+            
             string jsonResult = Request.Post(baseAddress,
                     RequestContent.EncodeAsJson(
                         JObject.Parse(context[Context.InitializeKernelJson] as string)),
@@ -76,13 +75,12 @@ namespace DataX.ServerScenarios
         public static StepResult RefreshSample(ScenarioContext context)
         {
             var baseAddress = $"{context[Context.ServiceUrl] as string}/api/DataX.Flow/Flow.SchemaInferenceService/inputdata/refreshsample";
-            context[Context.InferSchemaInputJson] = $"{{\"name\": \"{context[Context.FlowName] as string}\", \"userName\": \"{context[Context.FlowName] as string}\", \"eventhubConnectionString\": \"{context[Context.EventhubConnectionString] as string}\", \"eventHubNames\": \"{context[Context.EventHubName] as string}\", \"inputType\": \"iothub\", \"seconds\": \"{context[Context.Seconds] as string}\", \"databricksToken\": \"{context[Context.DataBricksToken] as string}\"}}";
+            
             string jsonResult = Request.Post(baseAddress,
                     RequestContent.EncodeAsJson(
                         JObject.Parse(context[Context.InferSchemaInputJson] as string)),
                     context[Context.AuthToken] as string);
             dynamic result = JObject.Parse(jsonResult);
-            //context[Context.InputSchema] = JsonConvert.SerializeObject((string)result.result.Schema);
             return new StepResult(((string)result.result).Contains("success"),
                 nameof(RefreshSample),
                 $"Refreshing Sample");
@@ -105,7 +103,6 @@ namespace DataX.ServerScenarios
                 nameof(RefreshSampleAndKernel),
                 $"Refresh the sample and kernel '{context[Context.KernelId]}' ");
         }
-
 
         [Step("deleteKernel")]
         public static StepResult DeleteKernel(ScenarioContext context)

--- a/Tests/DataXScenarios/DataXScenarios/InteractiveQueryAndSchemaGenScenarios.cs
+++ b/Tests/DataXScenarios/DataXScenarios/InteractiveQueryAndSchemaGenScenarios.cs
@@ -1,0 +1,125 @@
+﻿// *********************************************************************
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License
+// *********************************************************************
+using ScenarioTester;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DataX.ServerScenarios
+{
+    /// <summary>
+    /// Partial class defined such that the steps can be defined for the job 
+    /// </summary>
+    public partial class DataXHost
+    {
+        [Step("inferSchema")]
+        public static StepResult InferSchema(ScenarioContext context)
+        {
+            var baseAddress = $"{context[Context.ServiceUrl] as string}/api/DataX.Flow/Flow.SchemaInferenceService/inputdata/inferschema";
+            context[Context.InferSchemaInputJson] = $"{{\"name\": \"{context[Context.FlowName] as string}\", \"userName\": \"{context[Context.FlowName] as string}\", \"eventhubConnectionString\": \"{context[Context.EventhubConnectionString] as string}\", \"eventHubNames\": \"{context[Context.EventHubName] as string}\", \"inputType\": \"iothub\", \"seconds\": \"{context[Context.Seconds] as string}\", \"databricksToken\": \"{context[Context.DataBricksToken] as string}\"}}";
+            string jsonResult = Request.Post(baseAddress,
+                    RequestContent.EncodeAsJson(
+                        JObject.Parse(context[Context.InferSchemaInputJson] as string)),
+                    context[Context.AuthToken] as string);
+            dynamic result = JObject.Parse(jsonResult);
+            context[Context.InputSchema] = JsonConvert.SerializeObject((string)result.result.Schema);
+            return new StepResult(!string.IsNullOrWhiteSpace(context[Context.InputSchema] as string),
+                nameof(InferSchema),
+                $"Inferring Schema '{context[Context.InputSchema]}' ");
+        }
+
+        [Step("initializeKernel")]
+        public static StepResult InitializeKernel(ScenarioContext context)
+        {
+            var baseAddress = $"{context[Context.ServiceUrl] as string}/api/DataX.Flow/Flow.InteractiveQueryService/kernel";
+            
+            context[Context.InitializeKernelJson] = $"{{\"name\": \"{context[Context.FlowName] as string}\", \"userName\": \"{context[Context.FlowName] as string}\", \"eventhubConnectionString\": \"{context[Context.EventhubConnectionString] as string}\", \"eventHubNames\": \"{context[Context.EventHubName] as string}\", \"inputType\": \"iothub\", \"inputSchema\": {context[Context.InputSchema] as string}, \"kernelId\": \"{context[Context.KernelId] as string}\", \"normalizationSnippet\": {context[Context.NormalizationSnippet] as string}, \"databricksToken\": \"{context[Context.DataBricksToken] as string}\"}}";
+            
+            string jsonResult = Request.Post(baseAddress,
+                    RequestContent.EncodeAsJson(
+                        JObject.Parse(context[Context.InitializeKernelJson] as string)),
+                    context[Context.AuthToken] as string);
+
+            dynamic result = JObject.Parse(jsonResult);
+            context[Context.KernelId] = (string)result.result.result;
+
+            context[Context.InitializeKernelJson] = $"{{\"name\": \"{context[Context.FlowName] as string}\", \"userName\": \"{context[Context.FlowName] as string}\", \"eventhubConnectionString\": \"{context[Context.EventhubConnectionString] as string}\", \"eventHubNames\": \"{context[Context.EventHubName] as string}\", \"inputType\": \"iothub\", \"inputSchema\": {context[Context.InputSchema] as string}, \"kernelId\": \"{context[Context.KernelId] as string}\", \"normalizationSnippet\": {context[Context.NormalizationSnippet] as string}, \"databricksToken\": \"{context[Context.DataBricksToken] as string}\"}}";
+            
+            return new StepResult(!(string.IsNullOrWhiteSpace(context[Context.KernelId] as string) && (string) result.result.message==""),
+                nameof(InitializeKernel),
+                $"Initialize a kernel '{context[Context.KernelId]}' ");
+        }
+
+        [Step("refreshKernel")]
+        public static StepResult RefreshKernel(ScenarioContext context)
+        {
+            var baseAddress = $"{context[Context.ServiceUrl] as string}/api/DataX.Flow/Flow.InteractiveQueryService/kernel/refresh";
+            context[Context.InitializeKernelJson] = $"{{\"name\": \"{context[Context.FlowName] as string}\", \"userName\": \"{context[Context.FlowName] as string}\", \"eventhubConnectionString\": \"{context[Context.EventhubConnectionString] as string}\", \"eventHubNames\": \"{context[Context.EventHubName] as string}\", \"inputType\": \"iothub\", \"inputSchema\": {context[Context.InputSchema] as string}, \"kernelId\": \"{context[Context.KernelId] as string}\", \"normalizationSnippet\": {context[Context.NormalizationSnippet] as string}, \"databricksToken\": \"{context[Context.DataBricksToken] as string}\"}}";
+
+            string jsonResult = Request.Post(baseAddress,
+                    RequestContent.EncodeAsJson(
+                        JObject.Parse(context[Context.InitializeKernelJson] as string)),
+                    context[Context.AuthToken] as string);
+
+            dynamic result = JObject.Parse(jsonResult);
+            context[Context.KernelId] = (string)result.result.result;
+            return new StepResult(!(string.IsNullOrWhiteSpace(context[Context.KernelId] as string) && (string)result.result.message == ""),
+                nameof(RefreshKernel),
+                $"Refresh the kernel '{context[Context.KernelId]}' ");
+        }
+
+        [Step("refreshSample")]
+        public static StepResult RefreshSample(ScenarioContext context)
+        {
+            var baseAddress = $"{context[Context.ServiceUrl] as string}/api/DataX.Flow/Flow.SchemaInferenceService/inputdata/refreshsample";
+            context[Context.InferSchemaInputJson] = $"{{\"name\": \"{context[Context.FlowName] as string}\", \"userName\": \"{context[Context.FlowName] as string}\", \"eventhubConnectionString\": \"{context[Context.EventhubConnectionString] as string}\", \"eventHubNames\": \"{context[Context.EventHubName] as string}\", \"inputType\": \"iothub\", \"seconds\": \"{context[Context.Seconds] as string}\", \"databricksToken\": \"{context[Context.DataBricksToken] as string}\"}}";
+            string jsonResult = Request.Post(baseAddress,
+                    RequestContent.EncodeAsJson(
+                        JObject.Parse(context[Context.InferSchemaInputJson] as string)),
+                    context[Context.AuthToken] as string);
+            dynamic result = JObject.Parse(jsonResult);
+            //context[Context.InputSchema] = JsonConvert.SerializeObject((string)result.result.Schema);
+            return new StepResult(((string)result.result).Contains("success"),
+                nameof(RefreshSample),
+                $"Refreshing Sample");
+        }
+
+        [Step("refreshSampleAndKernel")]
+        public static StepResult RefreshSampleAndKernel(ScenarioContext context)
+        {
+            var baseAddress = $"{context[Context.ServiceUrl] as string}/api/DataX.Flow/Flow.LiveDataService/inputdata/refreshsampleandkernel";
+            context[Context.InitializeKernelJson] = $"{{\"name\": \"{context[Context.FlowName] as string}\", \"userName\": \"{context[Context.FlowName] as string}\", \"eventhubConnectionString\": \"{context[Context.EventhubConnectionString] as string}\", \"eventHubNames\": \"{context[Context.EventHubName] as string}\", \"inputType\": \"iothub\", \"inputSchema\": {context[Context.InputSchema] as string}, \"kernelId\": \"{context[Context.KernelId] as string}\", \"normalizationSnippet\": {context[Context.NormalizationSnippet] as string}, \"databricksToken\": \"{context[Context.DataBricksToken] as string}\"}}";
+
+            string jsonResult = Request.Post(baseAddress,
+                    RequestContent.EncodeAsJson(
+                        JObject.Parse(context[Context.InitializeKernelJson] as string)),
+                    context[Context.AuthToken] as string);
+
+            dynamic result = JObject.Parse(jsonResult);
+            context[Context.KernelId] = (string)result.result.result;
+            return new StepResult(!(string.IsNullOrWhiteSpace(context[Context.KernelId] as string) && (string)result.result.message == ""),
+                nameof(RefreshSampleAndKernel),
+                $"Refresh the sample and kernel '{context[Context.KernelId]}' ");
+        }
+
+
+        [Step("deleteKernel")]
+        public static StepResult DeleteKernel(ScenarioContext context)
+        {
+            var baseAddress = $"{context[Context.ServiceUrl] as string}/api/DataX.Flow/Flow.InteractiveQueryService/kernel/delete";
+            string json = JsonConvert.SerializeObject((string)context[Context.KernelId]);
+            string jsonResult = Request.Post(baseAddress,
+                    new RequestContent(Encoding.UTF8.GetBytes(json), "application/json"),
+                    context[Context.AuthToken] as string);
+            dynamic result = JObject.Parse(jsonResult);
+            return new StepResult(((string)result.result).Contains("Success"),
+                nameof(DeleteKernel),
+                $"Delete the kernel '{context[Context.KernelId]}' ");
+        }
+
+    }
+}

--- a/Tests/DataXScenarios/DataXScenarios/SaveAndDeploy.cs
+++ b/Tests/DataXScenarios/DataXScenarios/SaveAndDeploy.cs
@@ -31,7 +31,7 @@ namespace DataX.ServerScenarios
         }
         static public async Task GetS2SAccessTokenForProdMSAAsync(ScenarioContext context)
         {
-            await GetS2SAccessToken(context, context[Context.MicrosoftAuthority] as string, context[Context.DataHubIdentifier] as string, context[Context.ApplicationId] as string, context[Context.SecretKey] as string);
+            await GetS2SAccessToken(context, context[Context.MicrosoftAuthority] as string, context[Context.ApplicationIdentifierUri] as string, context[Context.ApplicationId] as string, context[Context.SecretKey] as string);
         }
 
         static async Task GetS2SAccessToken(ScenarioContext context, string authority, string resource, string clientId, string clientSecret)


### PR DESCRIPTION
Adding steps for a new JobRunner job calling into ScenarioTester. These steps are essentially calling into and testing the apis within InteractiveQueryService, LiveDataService and  SchemaGeneratorService. Also adding support for running the JobRunner on both DataBricks and HDInsight clusters.