### PR TITLE
Set internal transaction to false by default for bulk insert, The API…

### DIFF
--- a/DataProcessing/datax-host/src/main/scala/datax/sink/SqlOutputSetting.scala
+++ b/DataProcessing/datax-host/src/main/scala/datax/sink/SqlOutputSetting.scala
@@ -50,7 +50,7 @@ object SqlOutputSetting {
           queryTimeout = dict.getOrElse(SettingQueryTimeout,"30"),
           useBulkCopy = dict.getOrElse(SettingUseBulkCopy,"false").toBoolean,
           useBulkCopyTableLock = dict.getOrElse(SettingUseBulkCopyTablelock,"false"),
-          useBulkCopyInternalTransaction = dict.getOrElse(SettingUseBulkCopyInternalTransaction,"true"),
+          useBulkCopyInternalTransaction = dict.getOrElse(SettingUseBulkCopyInternalTransaction,"false"),
           bulkCopyTimeout = dict.getOrElse(SettingUseBulkCopyTimeout,"60"),
           bulkCopyBatchSize = dict.getOrElse(SettingUseBulkBatchSize,"2000")
         )


### PR DESCRIPTION
Set internal transaction to false by default for bulk insert, The API we are using doesn't accept this to be set to true.