### PR TITLE
enable to deploy the HDI cluster 4.0

### DIFF
--- a/DataProcessing/Spark.nuspec
+++ b/DataProcessing/Spark.nuspec
@@ -34,6 +34,7 @@
 <file src="**\hadoop-azure-2.7.3.jar" target="lib" />
 <file src="**\jetty-util-6.1.25.jar" target="lib" />
 <file src="**\json-20180813.jar" target="lib" />
+<file src="**\json4s-jackson_2.11-3.2.11.jar" target="lib" />
 <file src="**\azure-storage-3.1.0.jar" target="lib" />
 <file src="NOTICE.txt" target="" />
   </files>

--- a/DeploymentCloud/Deployment.Common/CosmosDB/commons.json
+++ b/DeploymentCloud/Deployment.Common/CosmosDB/commons.json
@@ -148,7 +148,8 @@
 				"wasbs:///datax/bin/java-uuid-generator-3.1.5.jar",
 				"wasbs:///datax/bin/proton-j-0.31.0.jar",
 				"wasbs:///datax/bin/scala-java8-compat_2.11-0.9.0.jar",
-				"wasbs:///datax/bin/azure-sqldb-spark-1.0.2.jar"
+				"wasbs:///datax/bin/azure-sqldb-spark-1.0.2.jar",
+				"wasbs:///datax/bin/json4s-jackson_2.11-3.2.11.jar"
 			],
 			"driverMemory": "1024m",
 			"executorCores": 2,
@@ -674,7 +675,8 @@
 							"wasbs:///datax/bin/scala-java8-compat_2.11-0.9.0.jar",
 							"wasbs:///datax/bin/spark-streaming-kafka-0-10_2.11-2.4.0.jar",
 							"wasbs:///datax/bin/kafka-clients-2.0.0.jar",
-							"wasbs:///datax/bin/azure-sqldb-spark-1.0.2.jar"
+							"wasbs:///datax/bin/azure-sqldb-spark-1.0.2.jar",
+							"wasbs:///datax/bin/json4s-jackson_2.11-3.2.11.jar"
 				],
 				"driverMemory" : "1024m",
 				"executorCores" : 2,
@@ -1078,7 +1080,8 @@
 					"wasbs:///datax/bin/java-uuid-generator-3.1.5.jar", 
 					"wasbs:///datax/bin/proton-j-0.31.0.jar",
 					"wasbs:///datax/bin/scala-java8-compat_2.11-0.9.0.jar",
-					"wasbs:///datax/bin/azure-sqldb-spark-1.0.2.jar"
+					"wasbs:///datax/bin/azure-sqldb-spark-1.0.2.jar",
+					"wasbs:///datax/bin/json4s-jackson_2.11-3.2.11.jar"
 				],
 				"driverMemory" : "1024m",
 				"executorCores" : 2,

--- a/DeploymentCloud/Deployment.Common/Resources/Parameters/Spark-AutoScale-Parameter.json
+++ b/DeploymentCloud/Deployment.Common/Resources/Parameters/Spark-AutoScale-Parameter.json
@@ -58,6 +58,12 @@
 		"sparkManagedIdentity": {	
 			"value": "$sparkManagedIdentityName"	
 		},
+		"minNodesForHDInsightAutoScaling": {
+			"value": $minNodesForHDInsightAutoScaling
+		},
+		"maxNodesForHDInsightAutoScaling": {
+			"value": $maxNodesForHDInsightAutoScaling
+		},
 		"minInstanceCountSparkHeadnode": {
 			"value": $minInstanceCountSparkHeadnode
 		},

--- a/DeploymentCloud/Deployment.Common/Resources/Templates/Spark-AutoScale-Template.json
+++ b/DeploymentCloud/Deployment.Common/Resources/Templates/Spark-AutoScale-Template.json
@@ -1,0 +1,206 @@
+{
+    "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#",
+    "contentVersion": "0.9.0.0",
+    "parameters": {
+        "default_resource_location": {
+            "type": "string"
+        },
+        "sparkClusterName": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of the HDInsight cluster to create."
+            }
+        },
+        "sparkClusterLoginUserName": {
+            "type": "string",
+            "metadata": {
+                "description": "These credentials can be used to submit jobs to the cluster and to log into cluster dashboards."
+            }
+        },
+        "sparkClusterLoginPassword": {
+            "type": "securestring",
+            "metadata": {
+                "description": "The password must be at least 10 characters in length and must contain at least one digit, one non-alphanumeric character, and one upper or lower case letter."
+            }
+        },
+        "sparkClusterVersion": {
+            "type": "string",
+            "metadata": {
+                "description": "HDInsight cluster version."
+            }
+        },
+        "sparkComponentVersion": {
+			"type": "string",
+			"metadata": {
+				"description": "HDInsight cluster spark component version."
+			}
+		},
+        "sparkClusterWorkerNodeCount": {
+            "type": "int",
+            "metadata": {
+                "description": "The number of nodes in the HDInsight cluster."
+            }
+        },
+        "sparkClusterKind": {
+            "type": "string",
+            "metadata": {
+                "description": "The type of the HDInsight cluster to create."
+            }
+        },
+        "sparkSshUserName": {
+            "type": "string",
+            "metadata": {
+                "description": "These credentials can be used to remotely access the cluster."
+            }
+        },
+        "sparkSshPassword": {
+            "type": "securestring",
+            "metadata": {
+                "description": "The password must be at least 10 characters in length and must contain at least one digit, one non-alphanumeric character, and one upper or lower case letter."
+            }
+        },
+        "storageAccounts_spark_name": {
+            "type": "String"
+        },
+        "sparkManagedIdentity": {
+            "type": "string"
+        },
+        "minNodesForHDInsightAutoScaling": {
+            "type": "int"
+        },
+        "maxNodesForHDInsightAutoScaling": {
+            "type": "int"
+        },
+        "minInstanceCountSparkHeadnode": {
+            "type": "int"
+        },
+        "targetInstanceCountSparkHeadnode": {
+            "type": "int"
+        },
+        "targetInstanceCountSparkWorkernode": {
+            "type": "int"
+        },
+        "vmSizeSparkHeadnode": {
+            "type": "string"
+        },
+        "vmSizeSparkWorkernode": {
+            "type": "string"
+        },
+        "userAssignedIdentitiesName": {
+            "type": "string"
+        },
+        "virtualNetworkName": {
+            "type": "string"
+        },
+        "subnet0Name": {
+            "type": "string"
+        }
+    },
+    "variables": {
+        "storageAccountsURI": "[concat(parameters('storageAccounts_spark_name'),'.blob.core.windows.net')]",
+        "storageAccountsResourceID": "[resourceId('Microsoft.Storage/storageAccounts',parameters('storageAccounts_spark_name'))]",
+        "userAssignedIdentitiesResourceID": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities',parameters('userAssignedIdentitiesName'))]",
+        "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',parameters('virtualNetworkName'))]",
+        "subnet0Ref": "[concat(variables('vnetID'),'/subnets/',parameters('subnet0Name'))]"
+    },
+    "resources": [
+        {
+            "apiVersion": "2015-08-31-preview",
+            "name": "[parameters('sparkManagedIdentity')]",
+            "location": "[parameters('default_resource_location')]",
+            "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+            "properties": {}
+        },
+        {
+            "apiVersion": "2015-03-01-preview",
+            "name": "[parameters('sparkClusterName')]",
+            "type": "Microsoft.HDInsight/clusters",
+            "location": "[parameters('default_resource_location')]",
+            "dependsOn": [
+                "[variables('userAssignedIdentitiesResourceID')]"
+            ],
+            "properties": {
+                "clusterVersion": "[parameters('sparkClusterVersion')]",
+                "osType": "Linux",
+                "tier": "standard",
+                "clusterDefinition": {
+                    "kind": "[parameters('sparkClusterKind')]",
+                    "componentVersion": {
+                        "Spark": "[parameters('sparkComponentVersion')]"
+                    },
+                    "configurations": {
+                        "gateway": {
+                            "restAuthCredential.isEnabled": true,
+                            "restAuthCredential.username": "[parameters('sparkClusterLoginUserName')]",
+                            "restAuthCredential.password": "[parameters('sparkClusterLoginPassword')]"
+                        }
+                    }
+                },
+                "storageProfile": {
+                    "storageaccounts": [
+                        {
+                            "name": "[variables('storageAccountsURI')]",
+                            "isDefault": true,
+                            "container": "defaultdx",
+                            "key": "[listKeys(variables('storageAccountsResourceID'), '2015-05-01-preview').key1]"
+                        }
+                    ]
+                },
+                "computeProfile": {
+                    "roles": [
+                        {
+                            "autoscale": null,
+                            "name": "headnode",
+                            "minInstanceCount": "[parameters('minInstanceCountSparkHeadnode')]",
+                            "targetInstanceCount": "[parameters('targetInstanceCountSparkHeadnode')]",
+                            "hardwareProfile": {
+                                "vmSize": "[parameters('vmSizeSparkHeadnode')]"
+                            },
+                            "osProfile": {
+                                "linuxOperatingSystemProfile": {
+                                    "username": "[parameters('sparkSshUserName')]",
+                                    "password": "[parameters('sparkSshPassword')]"
+                                }
+                            },
+                            "virtualNetworkProfile": {
+                                "id": "[variables('vnetID')]",
+                                "subnet": "[variables('subnet0Ref')]"
+                            },
+                            "scriptActions": []
+                        },
+                        {
+                            "autoscale": {
+                                "capacity": {
+                                    "minInstanceCount": "[parameters('minNodesForHDInsightAutoScaling')]",
+                                    "maxInstanceCount": "[parameters('maxNodesForHDInsightAutoScaling')]"
+                                }
+                            },
+                            "name": "workernode",
+                            "targetInstanceCount": "[parameters('targetInstanceCountSparkWorkernode')]",
+                            "hardwareProfile": {
+                                "vmSize": "[parameters('vmSizeSparkWorkernode')]"
+                            },
+                            "osProfile": {
+                                "linuxOperatingSystemProfile": {
+                                    "username": "[parameters('sparkSshUserName')]",
+                                    "password": "[parameters('sparkSshPassword')]"
+                                }
+                            },
+                            "virtualNetworkProfile": {
+                                "id": "[variables('vnetID')]",
+                                "subnet": "[variables('subnet0Ref')]"
+                            },
+                            "scriptActions": []
+                        }
+                    ]
+                }
+            },
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('userAssignedIdentitiesResourceID')]": {}
+                }
+            }
+        }
+    ]
+}

--- a/DeploymentCloud/Deployment.Common/Resources/Templates/Spark-Template.json
+++ b/DeploymentCloud/Deployment.Common/Resources/Templates/Spark-Template.json
@@ -28,6 +28,12 @@
 				"description": "HDInsight cluster version."
 			}
 		},
+		"sparkComponentVersion": {
+			"type": "string",
+			"metadata": {
+				"description": "HDInsight cluster spark component version."
+			}
+		},
 		"sparkClusterWorkerNodeCount": {
 			"type": "int",
 			"metadata": {
@@ -113,7 +119,7 @@
 				"clusterDefinition": {
 					"kind": "[parameters('sparkClusterKind')]",
 					"componentVersion": {
-						"Spark": "2.3"
+						"Spark": "[parameters('sparkComponentVersion')]"
 					},
 					"configurations": {
 						"gateway": {

--- a/DeploymentCloud/Deployment.Common/deployResources.ps1
+++ b/DeploymentCloud/Deployment.Common/deployResources.ps1
@@ -864,7 +864,7 @@ if($sparkCreation -eq 'y') {
             $sparkTemplate = "Spark-AutoScale-Template.json"
             $sparkParameter = "Spark-AutoScale-parameter.json"
         }      
-        Write-Host "sparkTempalte: '$sparkTemplate' ; sparkParameter: '$sparkParameter'"
+        Write-Host "sparkTemplate: '$sparkTemplate' ; sparkParameter: '$sparkParameter'"
 
 		Write-Host -ForegroundColor Green "Estimated time to complete: 20 mins"
 		Deploy-Resources -templateName  $sparkTemplate -paramName $sparkParameter -templatePath $templatePath -tokens $tokens

--- a/DeploymentCloud/Deployment.DataX/common.parameters.txt
+++ b/DeploymentCloud/Deployment.DataX/common.parameters.txt
@@ -35,6 +35,21 @@ databricksClusterNodeType=Standard_DS3_v2
 #Databricks SKU
 databricksSku=premium
 
+# HDInsight cluster version. Please use a whitelisted subscriptionId if you want to deploy version 4.0 (for now).
+HDInsightVersion=3.6
+
+# The spark version of the HDInsight. For HDInsight4.0, it can be 2.4 or 2.3. For HDInsight3.6, it should be 2.3
+sparkComponentVersion=2.3
+
+# y if you want to enable the auto-scaling feature of the HDInsight cluster. For now, it is only available for version 4.0.
+enableHDInsightAutoScaling=n
+
+# HDInsight minimal nodes. It is only meaning when HDInsightVersion=4.0 and enableHDInsightAutoScaling=y.
+minNodesForHDInsightAutoScaling=3
+
+# HDInsight maximal nodes. It is only meaning when HDInsightVersion=4.0 and enableHDInsightAutoScaling=y.
+maxNodesForHDInsightAutoScaling=5
+
 # y if you want to deploy Kafka sample, n otherwise
 # This will deploy the Kafka specific samples and resources such as HDinsight Kafka and EventHub Kafka  
 enableKafkaSample=y


### PR DESCRIPTION
1. added a new ARM template and its related parameter file for deploying the HDInsight 4.0 with autoScale enabled scenario.

2. parameterized the sparkClusterVersion and sparkComponentVersion parameters for the existing spark-template, so that it could be used for two scenarios:
    a. HDInsight 3.6 (existing scenario)
    b. HDInsight 4.0 with autoScale disabled (new scenario)

3. Default the deployment to HDInsight 3.6, so it would not impact existing deployment to 3.6