### PR TITLE
Added check for mdbc PSModule version

### DIFF
--- a/DeploymentCloud/Deployment.Common/deployResources.ps1
+++ b/DeploymentCloud/Deployment.Common/deployResources.ps1
@@ -133,6 +133,15 @@ function Install-Modules {
                 $moduleInstalled = $true
                 Install-Module -Name $_ -Force -AllowClobber -Scope CurrentUser -Repository PSGallery
             }
+	    
+	    # Since, Mdbc PS module doesn't support New-MdbcQuery cmdlet from v6.0.0, we have to make sure correct Mdbc module is installed.
+            # https://github.com/nightroman/Mdbc/blob/master/Release-Notes.md#v600
+            if ($_ -eq 'mdbc' -and !(Get-InstalledModule -Name $_ -RequiredVersion $modules.Item($_) -ErrorAction SilentlyContinue)) {
+                Write-Host "Install Module: " $_ " Version: "$modules.Item($_)
+                $moduleInstalled = $true
+                Install-Module -Name $_ -RequiredVersion $modules.Item($_) -Force -AllowClobber -Scope CurrentUser -Repository PSGallery
+                Import-Module -Name $_ -RequiredVersion $modules.Item($_)
+            }
     }
 
     if ($moduleInstalled) {

--- a/DeploymentCloud/Deployment.Common/deployResources.ps1
+++ b/DeploymentCloud/Deployment.Common/deployResources.ps1
@@ -126,27 +126,27 @@ function Install-Modules {
     $modules.Add("mdbc", " 5.1.4")
         
     $moduleInstalled = $false
+    # Make sure to install correct required version of PS modules.
+    # Since, Mdbc PS module doesn't support New-MdbcQuery cmdlet from v6.0.0, we have to make sure correct Mdbc module is installed.
+    # https://github.com/nightroman/Mdbc/blob/master/Release-Notes.md#v600
     $modules.Keys | foreach {
-            if (!(Get-installedModule -name $_ -MinimumVersion $modules.Item($_) -ErrorAction SilentlyContinue )) {
-    
+            if (!(Get-installedModule -name $_ -RequiredVersion $modules.Item($_) -ErrorAction SilentlyContinue )) {    
                 Write-Host "Install Module: " $_
                 $moduleInstalled = $true
                 Install-Module -Name $_ -Force -AllowClobber -Scope CurrentUser -Repository PSGallery
-            }
-	    
-	    # Since, Mdbc PS module doesn't support New-MdbcQuery cmdlet from v6.0.0, we have to make sure correct Mdbc module is installed.
-            # https://github.com/nightroman/Mdbc/blob/master/Release-Notes.md#v600
-            if ($_ -eq 'mdbc' -and !(Get-InstalledModule -Name $_ -RequiredVersion $modules.Item($_) -ErrorAction SilentlyContinue)) {
-                Write-Host "Install Module: " $_ " Version: "$modules.Item($_)
-                $moduleInstalled = $true
-                Install-Module -Name $_ -RequiredVersion $modules.Item($_) -Force -AllowClobber -Scope CurrentUser -Repository PSGallery
-                Import-Module -Name $_ -RequiredVersion $modules.Item($_)
             }
     }
 
     if ($moduleInstalled) {
         Write-Host -ForegroundColor Yellow "The script execution completed after one or more packages have been installed. In order to use the latest packages, please close this prompt, open a new command prompt as admin and run deploy.bat again"
         Exit 10
+    } else{
+        # Import correct version of PS modules.
+        $modules.Keys | ForEach-Object {
+            Write-Host "Importing Module: "$_" Version: "$modules.Item($_)
+            Import-Module -Name $_ -RequiredVersion $modules.Item($_) -Force
+            Write-Host "Imported Module: "$_" Version: "$modules.Item($_)
+        }
     }
 }
 


### PR DESCRIPTION
**Issue**: Deployment breaks due to New-MdbcQuery cmdlet doesn't found.

**Fix**:
Mdbc PSModule doesn't support New-MdbcQuery cmdlet from v6.0.0. we have to make sure correct Mdbc module (v5.1.4) is installed in the system during deployment.
Deployment uses New-MdbcQuery cmdlet to setup CosmosDb. 
$qry = New-MdbcQuery -Name "_id" -Exists