### PR TITLE
Add support for killed state

### DIFF
--- a/Services/DataX.Config/DataX.Config.LivyClient/LivyClient.cs
+++ b/Services/DataX.Config/DataX.Config.LivyClient/LivyClient.cs
@@ -186,6 +186,7 @@ namespace DataX.Config.LivyClient
                 case "running":return JobState.Running;
                 case "dead":return JobState.Idle;
                 case "success":return JobState.Success;
+                case "killed":return JobState.Idle;
                 default: throw new GeneralException($"Unexpected livy batch state:'{state}'");
             }
         }


### PR DESCRIPTION
Some versions of livy service responses are using "killed" state for terminated jobs. This change should make the backend to be able to handle that scenario.