### PR TITLE
Avoid building the regex if it is not actually used

### DIFF
--- a/DataProcessing/datax-host/src/main/scala/datax/input/BlobPointerInput.scala
+++ b/DataProcessing/datax-host/src/main/scala/datax/input/BlobPointerInput.scala
@@ -39,7 +39,7 @@ object BlobPointerInput {
     (new StructType).add("BlobPath", StringType)
   }
 
-  private val saRegex = s"""wasbs?://[\w-]+@([\w\d]+)\${BlobProperties.BlobHostPath}/.*""".r
+  private lazy val saRegex = s"""wasbs?://[\w-]+@([\w\d]+)\${BlobProperties.BlobHostPath}/.*""".r
   private def extractSourceId(blobPath: String, regex: String): String = {
     val r = if(regex == null) saRegex else regex.r
     r.findFirstMatchIn(blobPath) match {

--- a/DataProcessing/datax-host/src/test/scala/datax/test/input/BlobPointerInputTest.scala
+++ b/DataProcessing/datax-host/src/test/scala/datax/test/input/BlobPointerInputTest.scala
@@ -1,0 +1,13 @@
+package datax.test.input
+
+import datax.input.BlobPointerInput
+import org.scalatest.{FlatSpec, Matchers}
+
+class BlobPointerInputTest extends FlatSpec with Matchers{
+  org.apache.log4j.BasicConfigurator.configure()
+
+  "BlobPointerInput class" should "initialize correctly" in {
+    BlobPointerInput
+  }
+
+}


### PR DESCRIPTION
Under some circumstances, if the regex is started it crashes with  scala.StringContext$InvalidEscapeException. This can be avoided if the regex is provided through configuration using sourceidregex property. Make regex variable lazy, so it is instantiated when it needs to be used only.