### PR TITLE
Add a feature to force non empty batches

### DIFF
--- a/DataProcessing/datax-core/pom.xml
+++ b/DataProcessing/datax-core/pom.xml
@@ -51,7 +51,7 @@ SOFTWARE
 
   <groupId>com.microsoft.datax</groupId>
   <artifactId>datax-core_2.4_2.11</artifactId>
-  <version>1.2.6-SNAPSHOT</version>
+  <version>1.2.7-SNAPSHOT</version>
   <name>Data Accelerator Core</name>
   <description>This package contains the core module of Data Accelerator functionality.</description>
   <url>https://github.com/Microsoft/data-accelerator</url>

--- a/DataProcessing/datax-core/src/main/scala/datax/constants/JobArgument.scala
+++ b/DataProcessing/datax-core/src/main/scala/datax/constants/JobArgument.scala
@@ -18,4 +18,5 @@ object JobArgument {
   def ConfName_DefaultStorageAccount: String = s"${ConfNamePrefix}DEFAULTSTORAGEACCOUNT"
   def ConfName_DefaultContainer: String = s"${ConfNamePrefix}DEFAULTCONTAINER"
   def ConfName_AzureStorageJarPath: String = s"${ConfNamePrefix}AZURESTORAGEJARPATH"
+  def ConfName_ForceNonEmptyBatch: String = s"${ConfNamePrefix}FORCENONEMPTYBATCHES"
 }

--- a/DataProcessing/datax-host/pom.xml
+++ b/DataProcessing/datax-host/pom.xml
@@ -51,7 +51,7 @@ SOFTWARE
 
     <groupId>com.microsoft.datax</groupId>
     <artifactId>datax-host_2.4_2.11</artifactId>
-    <version>1.2.6-SNAPSHOT</version>
+    <version>1.2.7-SNAPSHOT</version>
 
     <properties>
         <spark.version>2.4.5</spark.version>
@@ -118,12 +118,12 @@ SOFTWARE
         <dependency>
             <groupId>com.microsoft.datax</groupId>
             <artifactId>datax-core_2.4_2.11</artifactId>
-            <version>1.2.6-SNAPSHOT</version>
+            <version>1.2.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.datax</groupId>
             <artifactId>datax-utility_2.4_2.11</artifactId>
-            <version>1.2.6-SNAPSHOT</version>
+            <version>1.2.7-SNAPSHOT</version>
         </dependency>		
         <dependency>
             <groupId>com.microsoft.azure</groupId>

--- a/DataProcessing/datax-host/src/main/scala/datax/processor/CommonProcessorFactory.scala
+++ b/DataProcessing/datax-host/src/main/scala/datax/processor/CommonProcessorFactory.scala
@@ -608,7 +608,12 @@ object CommonProcessorFactory {
               processPartition(pathsFilteredGroups(0))
           }
           else {
-            batchLog.warn(s"No valid paths is found to process for this batch")
+            batchLog.warn(s"No valid paths were found to process for this batch")
+            val bShouldForceNonEmptyBatch = ConfigManager.getActiveDictionary().getOrElse(JobArgument.ConfName_ForceNonEmptyBatch, "false").toBoolean
+            if(bShouldForceNonEmptyBatch)
+            {
+                  throw new Exception("No valid paths found to process for this batch and empty batches are not allowed")
+            }
             Map[String, Double]()
           }
         val batchProcessingTime = (System.nanoTime - t1) / 1E9

--- a/DataProcessing/datax-keyvault/pom.xml
+++ b/DataProcessing/datax-keyvault/pom.xml
@@ -51,7 +51,7 @@ SOFTWARE
 
   <groupId>com.microsoft.datax</groupId>
   <artifactId>datax-keyvault_2.4_2.11</artifactId>
-  <version>1.2.6-SNAPSHOT</version>
+  <version>1.2.7-SNAPSHOT</version>
 
   <properties>
     <spark.version>2.4.5</spark.version>

--- a/DataProcessing/datax-udf-samples/pom.xml
+++ b/DataProcessing/datax-udf-samples/pom.xml
@@ -51,7 +51,7 @@ SOFTWARE
 
     <groupId>com.microsoft.datax</groupId>
     <artifactId>datax-udf-samples_2.4_2.11</artifactId>
-    <version>1.2.6-SNAPSHOT</version>
+    <version>1.2.7-SNAPSHOT</version>
 
     <properties>
         <spark.version>2.4.5</spark.version>
@@ -113,7 +113,7 @@ SOFTWARE
         <dependency>
             <groupId>com.microsoft.datax</groupId>
             <artifactId>datax-core_2.4_2.11</artifactId>
-            <version>1.2.6-SNAPSHOT</version>
+            <version>1.2.7-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/DataProcessing/datax-utility/pom.xml
+++ b/DataProcessing/datax-utility/pom.xml
@@ -51,7 +51,7 @@ SOFTWARE
 
     <groupId>com.microsoft.datax</groupId>
     <artifactId>datax-utility_2.4_2.11</artifactId>
-    <version>1.2.6-SNAPSHOT</version>
+    <version>1.2.7-SNAPSHOT</version>
 
     <properties>
         <spark.version>2.4.5</spark.version>
@@ -120,7 +120,7 @@ SOFTWARE
         <dependency>
             <groupId>com.microsoft.datax</groupId>
             <artifactId>datax-core_2.4_2.11</artifactId>
-            <version>1.2.6-SNAPSHOT</version>
+            <version>1.2.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure</groupId>
@@ -130,7 +130,7 @@ SOFTWARE
         <dependency>
             <groupId>com.microsoft.datax</groupId>
             <artifactId>datax-keyvault_2.4_2.11</artifactId>
-            <version>1.2.6-SNAPSHOT</version>
+            <version>1.2.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure</groupId>


### PR DESCRIPTION
By adding a new configuration parameter name FORCENONEMPTYBATCHES, it will make the job crash if there are no valid input blob paths until finding at least one to process. This parameter is optional and is turned OFF by default if not included, thus, needs to be explicitly enabled.