### PR TITLE
drop blob without renaming in HadoopClient

### DIFF
--- a/DataProcessing/datax-host/src/main/scala/datax/checkpoint/EventhubCheckpointer.scala
+++ b/DataProcessing/datax-host/src/main/scala/datax/checkpoint/EventhubCheckpointer.scala
@@ -57,7 +57,7 @@ object EventhubCheckpointer {
     }
 
     HadoopClient.writeHdfsFile(checkpointFile,
-      offsets.map(v=>v._1+OffsetTokenSeparator+v._2+OffsetTokenSeparator+v._3+OffsetTokenSeparator+v._4+OffsetTokenSeparator+v._5).mkString("\n"), true, false)
+      offsets.map(v=>v._1+OffsetTokenSeparator+v._2+OffsetTokenSeparator+v._3+OffsetTokenSeparator+v._4+OffsetTokenSeparator+v._5).mkString("\n"), overwriteIfExists=true, directWrite=false)
   }
 
   def applyCheckpointsIfExists(ehConf: EventHubsConf, checkpointDir: String) = {

--- a/DataProcessing/datax-host/src/main/scala/datax/checkpoint/EventhubCheckpointer.scala
+++ b/DataProcessing/datax-host/src/main/scala/datax/checkpoint/EventhubCheckpointer.scala
@@ -57,7 +57,7 @@ object EventhubCheckpointer {
     }
 
     HadoopClient.writeHdfsFile(checkpointFile,
-      offsets.map(v=>v._1+OffsetTokenSeparator+v._2+OffsetTokenSeparator+v._3+OffsetTokenSeparator+v._4+OffsetTokenSeparator+v._5).mkString("\n"), true)
+      offsets.map(v=>v._1+OffsetTokenSeparator+v._2+OffsetTokenSeparator+v._3+OffsetTokenSeparator+v._4+OffsetTokenSeparator+v._5).mkString("\n"), true, false)
   }
 
   def applyCheckpointsIfExists(ehConf: EventHubsConf, checkpointDir: String) = {

--- a/DataProcessing/datax-host/src/main/scala/datax/fs/HadoopClient.scala
+++ b/DataProcessing/datax-host/src/main/scala/datax/fs/HadoopClient.scala
@@ -306,6 +306,7 @@ object HadoopClient {
     * @param hdfsPath path to the specified hdfs file
     * @param content string content to write into the file
     * @param overwriteIfExists flag to specify if the file needs to be overwritten if it already exists in hdfs
+    * @param skipRename flag to specify if the file needs to be created without renaming from a temp file
     * @throws IOException if any occurs in the write operation
     */
   @throws[IOException]
@@ -400,6 +401,7 @@ object HadoopClient {
     * @param content content to write into the file
     * @param conf hadoop configuration
     * @param overwriteIfExists flag to specify if the file needs to be overwritten if it already exists in hdfs
+    * @param skipRename flag to specify if the file needs to be created without renaming from a temp file
     * @param blobStorageKey storage account key broadcast variable
     * @throws IOException if any from lower file system operation
     */

--- a/DataProcessing/datax-host/src/main/scala/datax/fs/HadoopClient.scala
+++ b/DataProcessing/datax-host/src/main/scala/datax/fs/HadoopClient.scala
@@ -347,7 +347,7 @@ object HadoopClient {
                                 ) = {
     val logger = LogManager.getLogger(s"FileWriter${SparkEnvVariables.getLoggerSuffix()}")
     def f = Future{
-      writeHdfsFile(hdfsPath, content, getConf(), false, false, blobStorageKey)
+      writeHdfsFile(hdfsPath, content, getConf(), overwriteIfExists=false, directWrite=false, blobStorageKey)
     }
     var remainingAttempts = retries+1
     while(remainingAttempts>0) {

--- a/DataProcessing/datax-host/src/main/scala/datax/fs/HadoopClient.scala
+++ b/DataProcessing/datax-host/src/main/scala/datax/fs/HadoopClient.scala
@@ -434,9 +434,12 @@ object HadoopClient {
 
     // If skipRename is true, write the file directly to the target path without renaming from a temp file
     if (skipRename) {
-      val bs = new BufferedOutputStream(fs.create(path, true))
-      bs.write(content)
-      bs.close()
+      val outStream = fs.create(path, true)
+      if (content.length > 0) {
+        val bs = new BufferedOutputStream(outStream)
+        bs.write(content)
+        bs.close()
+      }
     } else {
       val bs = new BufferedOutputStream(fs.create(tempPath, true))
       bs.write(content)

--- a/DataProcessing/datax-host/src/main/scala/datax/handler/StateTableHandler.scala
+++ b/DataProcessing/datax-host/src/main/scala/datax/handler/StateTableHandler.scala
@@ -48,7 +48,7 @@ object StateTableHandler {
   }
 
   private def writeTableMetadata(metadataFile: String, parameters: HashMap[String, String]): Unit ={
-    HadoopClient.writeHdfsFile(metadataFile, parameters.map(i=>i._1+"="+i._2).mkString("\n"), true, false)
+    HadoopClient.writeHdfsFile(metadataFile, parameters.map(i=>i._1+"="+i._2).mkString("\n"), overwriteIfExists=true, directWrite=false)
   }
 
   private def getTableNameVersioned(name: String, suffix: String) = name+"_"+suffix

--- a/DataProcessing/datax-host/src/main/scala/datax/handler/StateTableHandler.scala
+++ b/DataProcessing/datax-host/src/main/scala/datax/handler/StateTableHandler.scala
@@ -48,7 +48,7 @@ object StateTableHandler {
   }
 
   private def writeTableMetadata(metadataFile: String, parameters: HashMap[String, String]): Unit ={
-    HadoopClient.writeHdfsFile(metadataFile, parameters.map(i=>i._1+"="+i._2).mkString("\n"), true)
+    HadoopClient.writeHdfsFile(metadataFile, parameters.map(i=>i._1+"="+i._2).mkString("\n"), true, false)
   }
 
   private def getTableNameVersioned(name: String, suffix: String) = name+"_"+suffix

--- a/DataProcessing/datax-host/src/main/scala/datax/host/BlobBatchingHost.scala
+++ b/DataProcessing/datax-host/src/main/scala/datax/host/BlobBatchingHost.scala
@@ -124,7 +124,7 @@ object BlobBatchingHost {
 
     val out = "_SUCCESS_" + dateFormat.format(dt)
     val outFilename = trackerFolder + out
-    HadoopClient.writeHdfsFile(outFilename, "success", true, true)
+    HadoopClient.writeHdfsFile(outFilename, "", true, true)
     appLog.warn(s"tracker file has been written: $outFilename")
 
   }

--- a/DataProcessing/datax-host/src/main/scala/datax/host/BlobBatchingHost.scala
+++ b/DataProcessing/datax-host/src/main/scala/datax/host/BlobBatchingHost.scala
@@ -124,7 +124,7 @@ object BlobBatchingHost {
 
     val out = "_SUCCESS_" + dateFormat.format(dt)
     val outFilename = trackerFolder + out
-    HadoopClient.writeHdfsFile(outFilename, "", true, true)
+    HadoopClient.writeHdfsFile(outFilename, "", overwriteIfExists=true, directWrite=true)
     appLog.warn(s"tracker file has been written: $outFilename")
 
   }

--- a/DataProcessing/datax-host/src/main/scala/datax/host/BlobBatchingHost.scala
+++ b/DataProcessing/datax-host/src/main/scala/datax/host/BlobBatchingHost.scala
@@ -124,7 +124,7 @@ object BlobBatchingHost {
 
     val out = "_SUCCESS_" + dateFormat.format(dt)
     val outFilename = trackerFolder + out
-    HadoopClient.writeHdfsFile(outFilename, "success", true)
+    HadoopClient.writeHdfsFile(outFilename, "success", true, true)
     appLog.warn(s"tracker file has been written: $outFilename")
 
   }

--- a/DataProcessing/datax-host/src/main/scala/datax/sink/OutputManager.scala
+++ b/DataProcessing/datax-host/src/main/scala/datax/sink/OutputManager.scala
@@ -85,7 +85,7 @@ object OutputManager {
           val spark = df.sparkSession
           spark.synchronized{
             if(shouldGeneratorProcessedSchema){
-              HadoopClient.writeHdfsFile(processedSchemaPath, new StructType(outputColumns).prettyJson, true)
+              HadoopClient.writeHdfsFile(processedSchemaPath, new StructType(outputColumns).prettyJson, true, false)
               outputLogger.warn(s"Saved processed schema to $processedSchemaPath")
               shouldGeneratorProcessedSchema = false
             }

--- a/DataProcessing/datax-host/src/main/scala/datax/sink/OutputManager.scala
+++ b/DataProcessing/datax-host/src/main/scala/datax/sink/OutputManager.scala
@@ -85,7 +85,7 @@ object OutputManager {
           val spark = df.sparkSession
           spark.synchronized{
             if(shouldGeneratorProcessedSchema){
-              HadoopClient.writeHdfsFile(processedSchemaPath, new StructType(outputColumns).prettyJson, true, false)
+              HadoopClient.writeHdfsFile(processedSchemaPath, new StructType(outputColumns).prettyJson, overwriteIfExists=true, directWrite=false)
               outputLogger.warn(s"Saved processed schema to $processedSchemaPath")
               shouldGeneratorProcessedSchema = false
             }


### PR DESCRIPTION
in order to solve the issue that no events triggered when blob file is created using abfs protocol, we should cancel the renaming step and drop the file directly to the location