### PR TITLE
fix json4s jackson runtime dependencies error

### DIFF
--- a/DataProcessing/datax-host/pom.xml
+++ b/DataProcessing/datax-host/pom.xml
@@ -133,7 +133,7 @@ SOFTWARE
         <dependency>
             <groupId>io.lettuce</groupId>
             <artifactId>lettuce-core</artifactId>
-            <version>6.1.6.RELEASE</version>
+            <version>6.1.8.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure</groupId>

--- a/DataProcessing/datax-keyvault/pom.xml
+++ b/DataProcessing/datax-keyvault/pom.xml
@@ -67,7 +67,7 @@ SOFTWARE
     <dependency>
       <groupId>org.json4s</groupId>
       <artifactId>json4s-jackson_2.11</artifactId>
-      <version>4.0.4</version>
+      <version>3.5.3</version>
     </dependency>
     <!--Azure dependencies-->
     <dependency>


### PR DESCRIPTION
This is to fix the runtime dependency error when fetching access token in KV client. In Spark 2.4, the compatible version of json4s jackson is 3.5.3. The program will run into java.NoSuchMethod error when 4.0.4 is set.