### PR TITLE
Jozavala/enableappinsights part2

### DIFF
--- a/DataProcessing/datax-host/src/main/scala/datax/sql/TransformSqlParser.scala
+++ b/DataProcessing/datax-host/src/main/scala/datax/sql/TransformSqlParser.scala
@@ -97,7 +97,7 @@ object TransformSQLParser {
   def replaceTableNames(statement: String, tableNameMappings: mutable.HashMap[String, String]) = {
     var result = statement
     for(mapping <- tableNameMappings){
-      result = result.replaceAll("\\b"+mapping._1+"\\b", mapping._2)
+      result = result.replaceAll("\\b"+mapping._1+"\\b", s"`${mapping._2}`")
     }
 
     result

--- a/DataProcessing/datax-host/src/main/scala/datax/telemetry/AppInsightLogger.scala
+++ b/DataProcessing/datax-host/src/main/scala/datax/telemetry/AppInsightLogger.scala
@@ -41,6 +41,8 @@ object AppInsightLogger extends TelemetryService {
   private var defaultProps = new scala.collection.mutable.HashMap[String, String]
   private var batchMetricProps = new scala.collection.mutable.HashMap[String, String]
 
+  def IsEnabled() = !client.isDisabled
+
   private def addContextProps(properties: Map[String, String]) = {
     defaultProps ++= properties.map(k=>("context."+k._1)->k._2)
     logger.info(s"add context properties:$properties")


### PR DESCRIPTION
This PR addresses three situations not covered in  #242:
- Allow application insight MetricLogger to work even if event hub and redis metrics are not enabled
- Avoid "invalid name" error when creating spark views and the generated select statement due to having names with non-alphanumeric characters such camel casing a name by using backticks
- Allow batch app to flush any pending metric before shutting down the app