### PR TITLE
Set the explicit number of retries for blob storage writes/reads

### DIFF
--- a/DataProcessing/datax-host/src/main/scala/datax/fs/HadoopClient.scala
+++ b/DataProcessing/datax-host/src/main/scala/datax/fs/HadoopClient.scala
@@ -45,6 +45,7 @@ object HadoopClient {
       hadoopConf = new Configuration()
       //Used to fetch fileSystem for wasbs
       hadoopConf.set("fs.wasbs.impl","org.apache.hadoop.fs.azure.NativeAzureFileSystem")
+      hadoopConf.set("fs.azure.io.retry.max.retries", "3")
     }
     else
       hadoopConf = conf

--- a/DataProcessing/datax-host/src/main/scala/datax/host/Logger.scala
+++ b/DataProcessing/datax-host/src/main/scala/datax/host/Logger.scala
@@ -4,6 +4,8 @@
 // *********************************************************************
 package datax.host
 
+import org.apache.hadoop.fs.azurebfs.AzureBlobFileSystemStore
+import org.apache.hadoop.fs.azurebfs.services.{AbfsClient, AbfsRestOperation}
 import org.apache.log4j.{Level, LogManager}
 
 object Logger {
@@ -13,5 +15,8 @@ object Logger {
     val logger = LogManager.getRootLogger
     logger.setLevel(level)
     logger.warn(s"root logger level set to ${level}")
+    LogManager.getLogger(classOf[AzureBlobFileSystemStore]).setLevel(level)
+    LogManager.getLogger(classOf[AbfsClient]).setLevel(level)
+    LogManager.getLogger(classOf[AbfsRestOperation]).setLevel(level)
   }
 }


### PR DESCRIPTION
This should make the job fail fast in case of Internal Server Error responses from storage account service instead of retrying infinitively until exhausting the application timeout.